### PR TITLE
Fix type checking of Type::Bits const params in instantiations

### DIFF
--- a/example-projects/rosenpass-basic/games/KEMAssumption.game.ssp
+++ b/example-projects/rosenpass-basic/games/KEMAssumption.game.ssp
@@ -12,11 +12,11 @@ composition KemAssumption {
 
   instance kem = KEM {
     params {
-      kem_sk_len: kem_sk_len,
-      kem_pk_len: kem_pk_len,
-      kem_ct_len: kem_ct_len,
-      kem_shk_len: kem_shk_len,
-      kem_encaps_coins_len: kem_encaps_coins_len,
+      sk_len: kem_sk_len,
+      pk_len: kem_pk_len,
+      ct_len: kem_ct_len,
+      shk_len: kem_shk_len,
+      encaps_coins_len: kem_encaps_coins_len,
 
       encaps: encaps,
     }

--- a/example-projects/rosenpass-basic/games/SillyProtocol.ssp
+++ b/example-projects/rosenpass-basic/games/SillyProtocol.ssp
@@ -11,11 +11,11 @@ composition SillyProtocol {
 
   instance kem = KEM {
     params {
-      kem_sk_len: kem_sk_len,
-      kem_pk_len: kem_pk_len,
-      kem_ct_len: kem_ct_len,
-      kem_shk_len: kem_shk_len,
-      kem_encaps_coins_len: kem_encaps_coins_len,
+      sk_len: kem_sk_len,
+      pk_len: kem_pk_len,
+      ct_len: kem_ct_len,
+      shk_len: kem_shk_len,
+      encaps_coins_len: kem_encaps_coins_len,
 
       encaps: encaps,
     }

--- a/example-projects/rosenpass-basic/packages/KEM.pkg.ssp
+++ b/example-projects/rosenpass-basic/packages/KEM.pkg.ssp
@@ -1,21 +1,21 @@
 package KEM {
   params {
-    kem_sk_len: Integer,
-    kem_pk_len: Integer,
-    kem_ct_len: Integer,
-    kem_shk_len: Integer,
-    kem_encaps_coins_len: Integer,
+    sk_len: Integer,
+    pk_len: Integer,
+    ct_len: Integer,
+    shk_len: Integer,
+    encaps_coins_len: Integer,
 
-    encaps: fn (Bits(kem_encaps_coins_len), Bits(kem_pk_len)) -> (Bits(kem_shk_len), Bits(kem_ct_len)),
+    encaps: fn (Bits(encaps_coins_len), Bits(pk_len)) -> (Bits(shk_len), Bits(ct_len)),
   }
 
   import oracles {
-    Set(key_id: Integer, key: Bits(kem_shk_len), is_uncorrupted: Bool),
-    Get(pk: Bits(kem_pk_len)) -> (Bits(kem_sk_len), Bool),
-    GetRand(key_id: Integer) -> (Bits(kem_encaps_coins_len), Bool),
+    Set(key_id: Integer, key: Bits(shk_len), is_uncorrupted: Bool),
+    Get(pk: Bits(pk_len)) -> (Bits(sk_len), Bool),
+    GetRand(key_id: Integer) -> (Bits(encaps_coins_len), Bool),
   }
 
-  oracle Encaps(key_id: Integer, pk: Bits(kem_pk_len)) -> Bits(kem_ct_len) {
+  oracle Encaps(key_id: Integer, pk: Bits(pk_len)) -> Bits(ct_len) {
     get <-invoke Get(pk);
     (_sk, sk_is_honest) <-parse get;
 

--- a/paper/tutorial.tex
+++ b/paper/tutorial.tex
@@ -207,6 +207,9 @@ In turn, $\M{Fwd}$ also has a $\O{UselessOracle}$ with the same code as in the $
 
 
 \subsection{Games}\label{sec:games}
+We explain the structure of a game on the examples of the games $\M{SmallComposition}$ and $\M{BigComposition}$ in hello-world/games.
+
+
 %To turn a package into a package instance, the game specifies
 %use the packages and finally one or multiple proof files which specify game instances
 %If you run cargo run prove in the hello-world folder, SSBee will verify the proof in hello-world (to be discussed shortly). If you run cargo run latex,

--- a/src/expressions.rs
+++ b/src/expressions.rs
@@ -129,6 +129,52 @@ impl Expression {
         }
     }
 
+    pub fn is_const(&self) -> bool {
+        match self {
+            Expression::Bot
+            | Expression::StringLiteral(_)
+            | Expression::IntegerLiteral(_)
+            | Expression::EmptyTable(_)
+            | Expression::None(_)
+            | Expression::BooleanLiteral(_) => true,
+
+            Expression::TableAccess(_, _) | Expression::FnCall(_, _) | Expression::Sample(_) => {
+                false
+            }
+
+            Expression::Not(expression)
+            | Expression::Neg(expression)
+            | Expression::Inv(expression)
+            | Expression::Some(expression)
+            | Expression::Unwrap(expression)
+            | Expression::Sum(expression)
+            | Expression::Prod(expression)
+            | Expression::Any(expression)
+            | Expression::All(expression)
+            | Expression::Union(expression)
+            | Expression::Cut(expression)
+            | Expression::SetDiff(expression) => expression.is_const(),
+
+            Expression::Identifier(ident) => ident.is_const(),
+
+            Expression::Tuple(exprs)
+            | Expression::List(exprs)
+            | Expression::Set(exprs)
+            | Expression::Equals(exprs)
+            | Expression::And(exprs)
+            | Expression::Or(exprs)
+            | Expression::Xor(exprs)
+            | Expression::Concat(exprs) => exprs.iter().all(Expression::is_const),
+
+            Expression::Add(lhs, rhs)
+            | Expression::Sub(lhs, rhs)
+            | Expression::Mul(lhs, rhs)
+            | Expression::Div(lhs, rhs)
+            | Expression::Pow(lhs, rhs)
+            | Expression::Mod(lhs, rhs) => lhs.is_const() && rhs.is_const(),
+        }
+    }
+
     pub fn walk(&mut self, f: &mut impl FnMut(&mut Expression) -> bool) {
         if !f(self) {
             return;

--- a/src/gamehops/equivalence/mod.rs
+++ b/src/gamehops/equivalence/mod.rs
@@ -160,7 +160,14 @@ impl<'a> EquivalenceContext<'a> {
 
         for tipe in self.types() {
             if let Type::Bits(id) = &tipe {
-                base_declarations.extend(hacks::BitsDeclaration(id.to_string()).into_iter());
+                let smt_expr: SmtExpr = match &**id {
+                    crate::types::CountSpec::Literal(num) => format!("{num}").into(),
+                    crate::types::CountSpec::Any => "*".into(),
+                    crate::types::CountSpec::Identifier(ident) => {
+                        ident.resolve_value().unwrap().into()
+                    }
+                };
+                base_declarations.extend(hacks::BitsDeclaration(smt_expr.to_string()).into_iter());
             }
         }
 

--- a/src/identifier.rs
+++ b/src/identifier.rs
@@ -463,7 +463,7 @@ pub mod game_ident {
         pub pkg_inst_name: String,
     }
 
-    #[derive(Debug, Clone, Hash, PartialOrd, Eq, Ord, PartialEq)]
+    #[derive(Debug, Clone, PartialOrd, Eq, Ord)]
     pub struct GameConstIdentifier {
         pub game_name: String,
         pub name: String,
@@ -472,6 +472,20 @@ pub mod game_ident {
         pub proof_name: Option<String>,
         pub inst_info: Option<GameIdentInstanciationInfo>,
         pub assigned_value: Option<Box<Expression>>,
+    }
+
+    impl PartialEq for GameConstIdentifier {
+        fn eq(&self, other: &Self) -> bool {
+            self.game_name == other.game_name && self.name == other.name && self.tipe == other.tipe
+        }
+    }
+
+    impl core::hash::Hash for GameConstIdentifier {
+        fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+            self.game_name.hash(state);
+            self.name.hash(state);
+            self.tipe.hash(state);
+        }
     }
 
     #[derive(Debug, Clone, Hash, PartialOrd, Eq, Ord, PartialEq)]
@@ -574,15 +588,21 @@ pub mod proof_ident {
         pub inst_info: Option<ProofIdentInstanciationInfo>,
     }
 
-    impl From<ProofConstIdentifier> for Identifier {
+    impl From<ProofConstIdentifier> for ProofIdentifier {
         fn from(value: ProofConstIdentifier) -> Self {
-            Identifier::ProofIdentifier(ProofIdentifier::Const(value))
+            ProofIdentifier::Const(value)
         }
     }
 
-    impl From<ProofLoopVarIdentifier> for Identifier {
+    impl From<ProofLoopVarIdentifier> for ProofIdentifier {
         fn from(value: ProofLoopVarIdentifier) -> Self {
-            Identifier::ProofIdentifier(ProofIdentifier::LoopVar(value))
+            ProofIdentifier::LoopVar(value)
+        }
+    }
+
+    impl<T: Into<ProofIdentifier>> From<T> for Identifier {
+        fn from(value: T) -> Self {
+            Identifier::ProofIdentifier(value.into())
         }
     }
 }

--- a/src/packageinstance.rs
+++ b/src/packageinstance.rs
@@ -122,7 +122,6 @@ pub(crate) mod instantiate {
             },
             proof_ident::ProofIdentInstanciationInfo,
         },
-        split::{SplitOracleDef, SplitOracleSig, SplitPath, SplitType},
         statement::{CodeBlock, IfThenElse, InvokeOracleStatement},
     };
 
@@ -359,10 +358,10 @@ pub(crate) mod instantiate {
         }
     }
 
-    impl<'a> InstantiationContext<'a> {
+    impl InstantiationContext<'_> {
         pub(crate) fn rewrite_expression(&self, expr: &Expression) -> Expression {
             expr.map(|expr| match (self.src, expr) {
-                (src, Expression::Identifier(ident)) => {
+                (_, Expression::Identifier(ident)) => {
                     Expression::Identifier(self.rewrite_identifier(ident))
                 }
 

--- a/src/packageinstance.rs
+++ b/src/packageinstance.rs
@@ -203,9 +203,9 @@ pub(crate) mod instantiate {
                     args: oracle_sig
                         .args
                         .into_iter()
-                        .map(|(name, tipe)| (name.clone(), tipe.rewrite(&type_rewrite_rules)))
+                        .map(|(name, tipe)| (name.clone(), tipe.rewrite_type(&type_rewrite_rules)))
                         .collect(),
-                    tipe: oracle_sig.tipe.rewrite(&type_rewrite_rules),
+                    tipe: oracle_sig.tipe.rewrite_type(&type_rewrite_rules),
                 }
             }
         }
@@ -312,7 +312,7 @@ pub(crate) mod instantiate {
                     self.rewrite_identifier(ident),
                     index.clone().map(|expr| self.rewrite_expression(&expr)),
                     sample_id,
-                    tipe.rewrite(&type_rewrite_rules),
+                    tipe.rewrite_type(&type_rewrite_rules),
                     pos,
                 ),
                 Statement::InvokeOracle(InvokeOracleStatement {
@@ -338,7 +338,9 @@ pub(crate) mod instantiate {
                         .into_iter()
                         .map(|expr| self.rewrite_expression(&expr))
                         .collect(),
-                    tipe: tipe.clone().map(|tipe| tipe.rewrite(&type_rewrite_rules)),
+                    tipe: tipe
+                        .clone()
+                        .map(|tipe| tipe.rewrite_type(&type_rewrite_rules)),
                 }),
 
                 Statement::IfThenElse(ite) => Statement::IfThenElse(IfThenElse {
@@ -510,19 +512,19 @@ pub(crate) mod instantiate {
                     let pkg_ident = match pkg_ident {
                         PackageIdentifier::Const(const_ident) => {
                             PackageIdentifier::Const(PackageConstIdentifier {
-                                tipe: const_ident.tipe.rewrite(&type_rewrite_rules),
+                                tipe: const_ident.tipe.rewrite_type(&type_rewrite_rules),
                                 ..const_ident
                             })
                         }
                         PackageIdentifier::State(state_ident) => {
                             PackageIdentifier::State(PackageStateIdentifier {
-                                tipe: state_ident.tipe.rewrite(&type_rewrite_rules),
+                                tipe: state_ident.tipe.rewrite_type(&type_rewrite_rules),
                                 ..state_ident
                             })
                         }
                         PackageIdentifier::Local(local_ident) => {
                             PackageIdentifier::Local(PackageLocalIdentifier {
-                                tipe: local_ident.tipe.rewrite(&type_rewrite_rules),
+                                tipe: local_ident.tipe.rewrite_type(&type_rewrite_rules),
                                 ..local_ident
                             })
                         }
@@ -533,7 +535,7 @@ pub(crate) mod instantiate {
 
                         PackageIdentifier::OracleArg(arg_ident) => {
                             PackageIdentifier::OracleArg(PackageOracleArgIdentifier {
-                                tipe: arg_ident.tipe.rewrite(&type_rewrite_rules),
+                                tipe: arg_ident.tipe.rewrite_type(&type_rewrite_rules),
                                 ..arg_ident.clone()
                             })
                         }

--- a/src/parser/common.rs
+++ b/src/parser/common.rs
@@ -168,7 +168,7 @@ pub(crate) fn handle_game_params_def_list(
     });
 
     // and then we chain the two again and do the rest of the processing
-    let result = ints
+    ints
         .into_iter()
         .chain(others_iter)
         .map(|res: Result<(pest::Span, Pair<Rule>, Pair<Rule>, Type), ParseGameError>| -> Result<(String, Expression), ParseGameError> {
@@ -223,9 +223,7 @@ pub(crate) fn handle_game_params_def_list(
             } else {
                 Ok(list)
             }
-        });
-
-    result
+        })
 }
 
 pub(crate) fn handle_proof_params_def_list(
@@ -237,7 +235,12 @@ pub(crate) fn handle_proof_params_def_list(
     let params = &game.consts;
     let mut defined_params = HashMap::<String, SourceSpan>::new();
     let block_span = ast.as_span();
-    ast.into_inner()
+
+    // We need to process ints first, so we can rewrite the Bits(<some int>) that contain the name
+    // of the const parameter on one side, and the name of the value that is assigned on the other.
+    // We first split the two...
+    let (ints, others): (Vec<_>, _) = ast
+        .into_inner()
         .map(|inner| {
             let pair_span = inner.as_span();
             let mut inner = inner.into_inner();
@@ -246,6 +249,81 @@ pub(crate) fn handle_proof_params_def_list(
 
             let name_span = name_ast.as_span();
             let name = name_ast.as_str();
+
+            // look up the parameter clone from the game
+            let maybe_param_info = params.iter().find(|(name_, _)| name == name_);
+
+            // if it desn't exist, return an error
+            let (_, expected_type) = maybe_param_info.ok_or(NoSuchGameParameterError {
+                source_code: ctx.named_source(),
+                at: (name_span.start()..name_span.end()).into(),
+                param_name: name.to_string(),
+                game_name: game.name.clone(),
+            })?;
+
+            Ok((pair_span, name_ast, value_ast, expected_type.clone()))
+        })
+        .partition(|result| matches!(result, Ok((_, _, _, Type::Integer))));
+
+    let mut bits_rewrite_rules = vec![];
+
+    // ... then we parse the ints and add populate a list of rewrite rules
+    //     for all the Bits types ...
+    let ints: Vec<_> = ints
+        .into_iter()
+        .map(|res| {
+            res.and_then(|(pair_span, name_ast, value_ast, expected_type)| {
+                // parse the assigned value, and set the expected type to what the clone
+                // prescribes.
+                let value = super::package::handle_expression(
+                    &ctx.parse_ctx(),
+                    value_ast.clone(),
+                    Some(&expected_type),
+                )?;
+
+                let assigned_const_text = match value {
+                    Expression::Identifier(ident) => ident.ident(),
+                    Expression::IntegerLiteral(num) => {
+                        format!("{num}")
+                    }
+                    other => {
+                        return Err(todo!());
+                    }
+                };
+
+                let name: &str = name_ast.as_str();
+
+                bits_rewrite_rules.push((
+                    Type::Bits(name.to_string()),
+                    Type::Bits(assigned_const_text),
+                ));
+
+                Ok((pair_span, name_ast, value_ast, expected_type))
+            })
+        })
+        .collect();
+
+    // ... then we map the other values to rewrite the types according to the rules defined
+    //     above ...
+    let others_iter = others.into_iter().map(|res| {
+        res.map(|(pair_span, name_ast, value_ast, ty)| {
+            (
+                pair_span,
+                name_ast,
+                value_ast,
+                ty.rewrite(&bits_rewrite_rules),
+            )
+        })
+    });
+
+    // and then we chain the two again and do the rest of the processing
+    ints
+        .into_iter()
+        .chain(others_iter)
+        .map(|res: Result<(pest::Span, Pair<Rule>, Pair<Rule>, Type), ParseProofError>| -> Result<(String, Expression), ParseProofError> {
+        let (pair_span, name_ast, value_ast, expected_type) = res?;
+        let name: &str = name_ast.as_str();
+        let name_span: pest::Span = name_ast.as_span();
 
             // check that the defined parameter hasn't been defined before
             // (insert returns Some(x) if x has been written before)
@@ -263,21 +341,11 @@ pub(crate) fn handle_proof_params_def_list(
                 .into());
             }
 
-            // look up the parameter clone from the game
-            let maybe_param_info = params.iter().find(|(name_, _)| name == name_);
-
-            // if it desn't exist, return an error
-            let (_, expected_type) = maybe_param_info.ok_or(NoSuchGameParameterError {
-                source_code: ctx.named_source(),
-                at: (name_span.start()..name_span.end()).into(),
-                param_name: name.to_string(),
-                game_name: game.name.clone(),
-            })?;
 
             let value = super::package::handle_expression(
                 &ctx.parse_ctx(),
                 value_ast,
-                Some(expected_type),
+                Some(&expected_type),
             )?;
 
             Ok((name.to_owned(), value.clone()))

--- a/src/parser/common.rs
+++ b/src/parser/common.rs
@@ -157,24 +157,6 @@ pub(crate) fn handle_game_params_def_list(
             // look up the parameter clone from the package
             let maybe_param_info = pkg.params.iter().find(|(name_, _, _)| name == name_);
 
-            panic!("This is where the bug is");
-
-            /*
-             *   The problem is that we are comparing package identifiers with game identifiers, and
-             *   they are techincally the same, but on one seide they are game indentifers but on
-             *   the other side they are package identifiers.
-             *
-             *   To show the actual error that occurs, comment out the panic above.
-             *
-             * */
-
-            match &maybe_param_info {
-                Some((_, Type::Fn(args, ret), _)) => {
-                    dbg!(args);
-                }
-                _ => {}
-            }
-
             // if it desn't exist, return an error
             let (_, expected_type, _) = maybe_param_info.ok_or(NoSuchPackageParameterError {
                 source_code: ctx.named_source(),
@@ -221,8 +203,8 @@ pub(crate) fn handle_game_params_def_list(
                                 pkg_name: pkg.name.clone(),
                                 name: name.to_string(),
                                 tipe: Type::Integer,
-                                game_name: Some(ctx.game_name.to_string()),
-                                pkg_inst_name: Some(pkg_inst_name.to_string()),
+                                game_name: None,
+                                pkg_inst_name: None,
                                 game_inst_name: None,
                                 proof_name: None,
                                 game_assignment: None,
@@ -381,8 +363,8 @@ pub(crate) fn handle_proof_params_def_list(
                             game_name: game.name.clone(),
                             name: name.to_string(),
                             tipe: Type::Integer,
-                            game_inst_name: Some(game_inst_name.to_string()),
-                            proof_name: Some(ctx.proof_name.to_string()),
+                            game_inst_name: None,
+                            proof_name: None,
                             inst_info: None,
                             assigned_value: None,
                         }),

--- a/src/parser/composition.rs
+++ b/src/parser/composition.rs
@@ -206,7 +206,7 @@ pub enum ParseGameError {
 
     #[diagnostic(transparent)]
     #[error(transparent)]
-    NoSuchType(#[from] NoSuchTypeError),
+    HandleType(#[from] HandleTypeError),
 
     #[diagnostic(transparent)]
     #[error(transparent)]
@@ -260,6 +260,7 @@ pub fn handle_comp_spec_list<'a>(
                             inst_info: None,
                             game_inst_name: None,
                             proof_name: None,
+                            assigned_value: None,
                         }
                         .into(),
                     ),

--- a/src/parser/composition.rs
+++ b/src/parser/composition.rs
@@ -2,10 +2,9 @@ use super::{
     common::*,
     error::{
         DuplicateEdgeDefinitionError, DuplicatePackageParameterDefinitionError,
-        InvalidGameInstanceInReductionError, MissingEdgeForImportedOracleError,
-        MissingPackageParameterDefinitionError, NoSuchPackageParameterError, NoSuchTypeError,
-        UndefinedOracleError, UndefinedPackageError, UndefinedPackageInstanceError,
-        UnusedEdgeError,
+        MissingEdgeForImportedOracleError, MissingPackageParameterDefinitionError,
+        NoSuchPackageParameterError, UndefinedOracleError, UndefinedPackageError,
+        UndefinedPackageInstanceError, UnusedEdgeError,
     },
     package::{handle_expression, ForComp, MultiInstanceIndices, ParsePackageError},
     ParseContext, Rule,
@@ -485,7 +484,6 @@ pub fn handle_compose_assign_body_list(
                 &source_instance_idx,
                 source_pkgidx,
             )? {
-                println!("found edge {:?}", multi_instance_edge);
                 match multi_instance_edge.try_into() {
                     Ok(edge) => ctx.add_edge(edge),
                     Err(NotSingleInstanceEdgeError(multi_edge)) => {
@@ -499,19 +497,25 @@ pub fn handle_compose_assign_body_list(
     Ok(())
 }
 
+/// parses the oracle wiring assignment list for the exports.
 fn handle_export_compose_assign_list_multi_inst(
     ctx: &mut ParseGameContext,
     ast: Pair<Rule>,
 ) -> Result<Vec<MultiInstanceExport>, ParseGameError> {
+    // compose_assign_list = { compose_assign ~ ( "," ~ compose_assign )* ~ ","? }
     assert_eq!(ast.as_rule(), Rule::compose_assign_list);
 
     let mut exports = vec![];
 
+    // Iterate over the assignment pairs
     for assignment in ast.into_inner() {
+        // compose_assign = { compose_assign_modifier? ~ identifier ~ ":" ~ identifier }
         assert_eq!(assignment.as_rule(), Rule::compose_assign);
 
         let mut assignment = assignment.into_inner();
 
+        // extract the base information from the parse tree. This is a bit tricky, because we may
+        // start with an optional modifier.
         let first = assignment.peek().unwrap();
         let (modifier_ast, oracle_name_ast, dst_pkg_inst_name_ast) = match first.as_rule() {
             Rule::identifier => {
@@ -520,6 +524,7 @@ fn handle_export_compose_assign_list_multi_inst(
                 (None, oracle_name, dst_inst_name)
             }
             Rule::compose_assign_modifier_with_index => {
+                // compose_assign_modifier_with_index =  { "with" ~ "index" ~ indices_expr}
                 let modifier = assignment.next().unwrap();
                 let oracle_name = assignment.next().unwrap();
                 let dst_inst_name = assignment.next().unwrap();
@@ -533,6 +538,7 @@ fn handle_export_compose_assign_list_multi_inst(
         let dst_pkg_inst_name = dst_pkg_inst_name_ast.as_str();
         let dst_pkg_inst_name_span = dst_pkg_inst_name_ast.as_span();
 
+        // parse the index modifiers. currently we don't use this.
         let dst_inst_idx: Option<Vec<Expression>> = modifier_ast
             .map(|modifier| {
                 modifier
@@ -545,6 +551,7 @@ fn handle_export_compose_assign_list_multi_inst(
             })
             .transpose()?;
 
+        // look up destination package instance
         let (dst_offset, dst_inst) =
             ctx.get_pkg_instance(dst_pkg_inst_name)
                 .ok_or(UndefinedPackageInstanceError {
@@ -554,7 +561,8 @@ fn handle_export_compose_assign_list_multi_inst(
                     in_game: ctx.game_name.to_string(),
                 })?;
 
-        let mut oracle_sig = dst_inst
+        // look up authorative oracle signature from destination package instance
+        let oracle_sig = dst_inst
             .pkg
             .oracles
             .iter()
@@ -569,9 +577,17 @@ fn handle_export_compose_assign_list_multi_inst(
 
         assert!(oracle_sig.multi_inst_idx.indices.is_empty());
 
-        if let Some(indices) = dst_inst_idx {
-            oracle_sig.multi_inst_idx = MultiInstanceIndices { indices };
-        }
+        // refine the indices (not sure this is correct, but we don't do this now anyway)
+        let oracle_sig = match dst_inst_idx.map(MultiInstanceIndices::new) {
+            Some(multi_inst_idx) => OracleSig {
+                multi_inst_idx,
+                ..oracle_sig
+            },
+            None => oracle_sig,
+        };
+
+        // make the signature use the constants from the game, not the package
+        let oracle_sig = dst_inst.instantiate_oracle_signature(oracle_sig);
 
         exports.push(MultiInstanceExport {
             dest_pkgidx: dst_offset,
@@ -582,21 +598,27 @@ fn handle_export_compose_assign_list_multi_inst(
     Ok(exports)
 }
 
+/// parses the oracle wiring assignment list for the package instance with index `source_pkgidx`.
 fn handle_edges_compose_assign_list_multi_inst(
     ctx: &mut ParseGameContext,
     ast: Pair<Rule>,
     source_instance_idx: &[Identifier],
     source_pkgidx: usize,
 ) -> Result<Vec<MultiInstanceEdge>, ParseGameError> {
+    // compose_assign_list = { compose_assign ~ ( "," ~ compose_assign )* ~ ","? }
     assert_eq!(ast.as_rule(), Rule::compose_assign_list);
 
     let mut edges = vec![];
 
+    // Iterate over the assignment pairs
     for assignment in ast.into_inner() {
+        // compose_assign = { compose_assign_modifier? ~ identifier ~ ":" ~ identifier }
         assert_eq!(assignment.as_rule(), Rule::compose_assign);
 
         let mut assignment = assignment.into_inner();
 
+        // extract the base information from the parse tree. This is a bit tricky, because we may
+        // start with an optional modifier.
         let first = assignment.peek().unwrap();
         let (modifier_ast, oracle_name_ast, dst_pkg_inst_name_ast) = match first.as_rule() {
             Rule::identifier => {
@@ -605,6 +627,7 @@ fn handle_edges_compose_assign_list_multi_inst(
                 (None, oracle_name, dst_inst_name)
             }
             Rule::compose_assign_modifier_with_index => {
+                // compose_assign_modifier_with_index =  { "with" ~ "index" ~ indices_expr}
                 let modifier = assignment.next().unwrap();
                 let oracle_name = assignment.next().unwrap();
                 let dst_inst_name = assignment.next().unwrap();
@@ -618,6 +641,7 @@ fn handle_edges_compose_assign_list_multi_inst(
         let dst_pkg_inst_name = dst_pkg_inst_name_ast.as_str();
         let dst_pkg_inst_name_span = dst_pkg_inst_name_ast.as_span();
 
+        // parse the index modifiers. currently we don't use this.
         let dst_inst_idx: Option<Vec<Expression>> = modifier_ast
             .map(|modifier| {
                 modifier
@@ -630,6 +654,7 @@ fn handle_edges_compose_assign_list_multi_inst(
             })
             .transpose()?;
 
+        // look up destination package instance
         let (dst_offset, dst_inst) =
             ctx.get_pkg_instance(dst_pkg_inst_name)
                 .ok_or(UndefinedPackageInstanceError {
@@ -639,19 +664,7 @@ fn handle_edges_compose_assign_list_multi_inst(
                     in_game: ctx.game_name.to_string(),
                 })?;
 
-        let mut oracle_sig = dst_inst
-            .pkg
-            .oracles
-            .iter()
-            .find(|oracle_def| oracle_def.sig.name == oracle_name)
-            .ok_or(UndefinedOracleError {
-                source_code: ctx.named_source(),
-                at: (oracle_name_span.start()..oracle_name_span.end()).into(),
-                oracle_name: oracle_name.to_string(),
-            })?
-            .sig
-            .clone();
-
+        // fail if imported edge is not assigned
         let (src_pkg_inst, _) = &ctx.instances[source_pkgidx];
         if src_pkg_inst
             .pkg
@@ -669,9 +682,31 @@ fn handle_edges_compose_assign_list_multi_inst(
             }));
         }
 
-        if let Some(indices) = dst_inst_idx {
-            oracle_sig.multi_inst_idx = MultiInstanceIndices { indices };
-        }
+        // look up authorative oracle signature from destination package instance
+        let oracle_sig = dst_inst
+            .pkg
+            .oracles
+            .iter()
+            .find(|oracle_def| oracle_def.sig.name == oracle_name)
+            .ok_or(UndefinedOracleError {
+                source_code: ctx.named_source(),
+                at: (oracle_name_span.start()..oracle_name_span.end()).into(),
+                oracle_name: oracle_name.to_string(),
+            })?
+            .sig
+            .clone();
+
+        // refine the indices (not sure this is correct, but we don't do this now anyway)
+        let oracle_sig = match dst_inst_idx.map(MultiInstanceIndices::new) {
+            Some(multi_inst_idx) => OracleSig {
+                multi_inst_idx,
+                ..oracle_sig
+            },
+            None => oracle_sig,
+        };
+
+        // make the signature use the constants from the game, not the package
+        let oracle_sig = dst_inst.instantiate_oracle_signature(oracle_sig);
 
         if edges.iter().any(|existing_edge: &MultiInstanceEdge| {
             // TODO: this will probably fail for real multi-instance, handle that later

--- a/src/parser/error.rs
+++ b/src/parser/error.rs
@@ -572,6 +572,22 @@ pub struct DuplicateEdgeDefinitionError {
     pub game_name: String,
 }
 
+#[derive(Error, Debug, miette::Diagnostic)]
+#[error("Error parsing '{num_str}' as a number: {source}")]
+#[diagnostic(code(ssbee::code::number_parse))]
+pub struct ParseNumberError {
+    #[source_code]
+    pub source_code: miette::NamedSource<String>,
+
+    #[label("this number could not be parsed")]
+    pub at: SourceSpan,
+
+    pub num_str: String,
+
+    #[source]
+    pub source: <u64 as std::str::FromStr>::Err,
+}
+
 #[derive(miette::Diagnostic, Debug, thiserror::Error)]
 #[error("Reduction references construction game instance {name}, but that is not in the header")]
 pub struct InvalidGameInstanceInReductionError {

--- a/src/parser/package.rs
+++ b/src/parser/package.rs
@@ -115,7 +115,7 @@ pub enum ParsePackageError {
 
     #[diagnostic(transparent)]
     #[error(transparent)]
-    NoSuchType(#[from] NoSuchTypeError),
+    HandleType(#[from] HandleTypeError),
 
     #[diagnostic(transparent)]
     #[error(transparent)]
@@ -243,8 +243,8 @@ pub fn handle_decl_list(
     decl_list: Pair<Rule>,
     ident_type: IdentType,
 ) -> Result<(), ParsePackageError> {
-    let parse_ctx = ctx.parse_ctx();
     for entry in decl_list.into_inner() {
+        let parse_ctx = ctx.parse_ctx();
         let span = entry.as_span();
         let mut inner = entry.into_inner();
         let name_ast = inner.next().unwrap();
@@ -301,7 +301,7 @@ pub fn handle_decl_list(
 pub fn handle_arglist(
     ctx: &ParsePackageContext,
     arglist: Pair<Rule>,
-) -> Result<Vec<(String, Type)>, NoSuchTypeError> {
+) -> Result<Vec<(String, Type)>, HandleTypeError> {
     let parse_ctx = ctx.parse_ctx();
 
     arglist
@@ -327,7 +327,7 @@ pub enum ParseExpressionError {
 
     #[diagnostic(transparent)]
     #[error(transparent)]
-    NoSuchType(#[from] NoSuchTypeError),
+    HandleType(#[from] HandleTypeError),
 
     #[diagnostic(transparent)]
     #[error(transparent)]
@@ -736,7 +736,7 @@ pub fn handle_identifier_in_code_rhs(
 ) -> Result<Identifier, ParseIdentifierError> {
     let ident = scope
         .lookup(name)
-        .ok_or(ParseIdentifierError::Undefined(name.to_string()))?
+        .ok_or(ParseIdentifierError::Undefined(name.to_string())).unwrap()
         .into_identifier()
         .unwrap_or_else(|decl| panic!("expected an identifier, got a clone {decl:?}", decl = decl));
 

--- a/src/parser/proof.rs
+++ b/src/parser/proof.rs
@@ -26,14 +26,11 @@ use crate::{
     },
     proof::{Claim, GameInstance, Proof},
     types::Type,
-    util::{
-        resolver::{Resolver, SliceResolver},
-        scope::{Declaration, Error as ScopeError, Scope},
-    },
+    util::scope::{Declaration, Error as ScopeError, Scope},
 };
 
 use itertools::Itertools;
-use miette::{Diagnostic, NamedSource, SourceSpan};
+use miette::{Diagnostic, NamedSource};
 use pest::{
     iterators::{Pair, Pairs},
     Span,
@@ -47,7 +44,7 @@ use super::{
         AssumptionMappingParameterMismatchError,
         AssumptionMappingRightGameInstanceIsFromAssumption, DuplicateGameParameterDefinitionError,
         InvalidGameInstanceInReductionError, MissingGameParameterDefinitionError,
-        NoSuchGameParameterError, NoSuchTypeError, ReductionInconsistentAssumptionBoundaryError,
+        NoSuchGameParameterError, ReductionInconsistentAssumptionBoundaryError,
         ReductionPackageInstanceParameterMismatchError, UndefinedAssumptionError,
         UndefinedGameError, UndefinedGameInstanceError, UndefinedPackageInstanceError,
     },

--- a/src/parser/proof.rs
+++ b/src/parser/proof.rs
@@ -41,7 +41,7 @@ use pest::{
 use thiserror::Error;
 
 use super::{
-    common,
+    common::{self, HandleTypeError},
     error::{
         AssumptionExportsNotSufficientError, AssumptionMappingMissesPackageInstanceError,
         AssumptionMappingParameterMismatchError,
@@ -187,7 +187,7 @@ pub enum ParseProofError {
 
     #[diagnostic(transparent)]
     #[error(transparent)]
-    NoSuchType(#[from] NoSuchTypeError),
+    HandleType(#[from] HandleTypeError),
 
     #[diagnostic(transparent)]
     #[error(transparent)]
@@ -362,9 +362,10 @@ fn handle_instance_assign_list(
                             game_name: game.name.to_string(),
                             name,
                             tipe: value.get_type(),
+                            assigned_value: Some(Box::new(value.clone())),
                             inst_info: None,
-                            game_inst_name: None,
-                            proof_name: None,
+                            game_inst_name: Some(game_inst_name.to_string()),
+                            proof_name: Some(ctx.proof_name.to_string()),
                         },
                         value,
                     )

--- a/src/parser/reduction.rs
+++ b/src/parser/reduction.rs
@@ -163,42 +163,19 @@ fn compare_reduction(
         PackageInstanceDiff::Same => {}
     }
 
-    // these are the same in both games, because the package name is the same
+    // Compare that the _outgoing_ edges of the two package instances match.
+    // These are the same in both games, because the package name is the same
     for (sig, _) in &left_pkg_inst.pkg.imports {
-        dbg!(sig);
-        dbg!(&game_left.edges);
-
         let left_edge = game_left
             .edges
             .iter()
-            .find(|edge| edge.from() == inst_offs_left && edge.sig() == sig)
-            .unwrap_or_else(|| {
-                let edge = game_left
-                    .edges
-                    .iter()
-                    .find(|edge| edge.from() == inst_offs_left && edge.sig().name == sig.name)
-                    .unwrap();
+            .find(|edge| edge.from() == inst_offs_left && edge.sig().name == sig.name)
+            .unwrap();
 
-                panic!("failed to find edge {edge:?} by comapring with signature {sig:?}");
-
-                // again, the problem is that there is a Bits(_) type in the signature.
-                // what is new is that we are on the level of proofs here, so we need another layer
-                // of instantiation here.
-                // Or we add a nestable EqWithContext somehow. I am not sure that is a good idea,
-                // but let's play with the idea for a bit.
-                //
-                // Actually let's do that somewhere else.
-                //
-                // ----
-                //
-                // Alternative idea: rewrite during instantiation and put that piece of info
-                // somewhere. For some things we already do that, but these are just strings, not
-                // identifiers. maybe that is the actual problem. Let's try to change that
-            });
         let right_edge = game_right
             .edges
             .iter()
-            .find(|edge| edge.from() == inst_offs_right && edge.sig() == sig)
+            .find(|edge| edge.from() == inst_offs_right && edge.sig().name == sig.name)
             .unwrap();
 
         compare_reduction(
@@ -339,7 +316,7 @@ fn handle_reduction_body<'a>(
             .game()
             .exports
             .iter()
-            .find(|export| export.sig() == left_export.sig())
+            .find(|right_export| left_export.sig().name == right_export.sig().name)
             .unwrap();
 
         compare_reduction(
@@ -727,18 +704,6 @@ fn handle_mapspec_assumption<'a>(
                 .enumerate()
                 .map(|(i, pkg_inst)| (i, pkg_inst.name(), pkg_inst.pkg_name()))
                 .collect();
-
-            dbg!(&construction_game_inst_name);
-            dbg!(&construction_game_inst.game_name());
-            dbg!(&assumption_game_inst_name);
-            dbg!(&assumption_game_inst.game_name());
-            dbg!(constr_src);
-            dbg!(constr_dst);
-            dbg!(constr_sig);
-            dbg!(dst_pkginst_mapping);
-            dbg!(src_is_in_reduction_part);
-            dbg!(assump_pkgs);
-            dbg!(constr_pkgs);
         }
 
         // ignore edges that start in mapped packages, because we are only interested in cross-cut
@@ -751,19 +716,23 @@ fn handle_mapspec_assumption<'a>(
             let constr_dst_pkg_inst = &construction_game_inst.game().pkgs[*constr_dst];
             let assump_dst_pkg_inst = &assumption_game_inst.game().pkgs[*assump_dst];
 
-            dbg!(&constr_dst_pkg_inst.pkg.name);
-            dbg!(&assump_dst_pkg_inst.pkg.name);
+            // this lookup is by comparing the oracle name, not the whole signature
+            let assump_dst_export =
+                assumption_game_inst.game().exports.iter().find(|export| {
+                    export.to() == *assump_dst && export.sig().name == constr_sig.name
+                });
 
-            let assump_dst_export = assumption_game_inst
-                .game()
-                .exports
-                .iter()
-                .find(|export| export.to() == *assump_dst && export.sig() == constr_sig);
-
-            dbg!(assump_dst_export);
+            // These show the problem: one is a GameConstIdentifier and the other is a
+            // PackageConstIdentifier. Both should be ProofIdentifiers.
+            //
+            // Okay, now at least both are game const identifiers. I still need to make them proof
+            //  indentifers
+            let constr_sig_owned =
+                construction_game_inst.instantiate_oracle_signature(constr_sig.clone());
+            let constr_sig = &constr_sig_owned;
 
             // if it's cross-cut, it needs to be exported, else error out
-            if assump_dst_export.is_none() {
+            let Some(assump_dst_export) = assump_dst_export else {
                 let assumption_dst_name = &assumption_game_inst.game().pkgs[*assump_dst].name;
                 let (assumption_ast, construction_ast) = mappings
                     .iter()
@@ -791,7 +760,16 @@ fn handle_mapspec_assumption<'a>(
                     oracle_name,
                 }
                 .into());
-            }
+            };
+
+            // rewrite the destination oracle signature as welll and compare to check that they
+            // match
+            let assump_sig_fixed =
+                assumption_game_inst.instantiate_oracle_signature(assump_dst_export.sig().clone());
+            let constr_sig_fixed =
+                construction_game_inst.instantiate_oracle_signature(constr_sig.clone());
+
+            debug_assert_eq!(constr_sig_fixed, assump_sig_fixed);
 
             // check that the destination packages in construction and assumption are equivalent
 
@@ -823,42 +801,25 @@ fn handle_mapspec_assumption<'a>(
 
         // edge exists in construction => edge exists in assumption
         for construction_edge in construction_game_assumptionpart_edges {
-            dbg!(construction_edge);
-            dbg!(
-                &construction_game_inst.game().pkgs[*constr_src_pkg_inst_offs]
-                    .pkg
-                    .name
-            );
-            dbg!(
-                &assumption_game_inst.game().pkgs[*assump_src_pkg_inst_offs]
-                    .pkg
-                    .name
-            );
             let (_, assumption_game_to) = pkg_offset_mapping
                 .iter()
                 .find(|(constr, _)| *constr == construction_edge.to())
                 .unwrap();
 
-            dbg!(
-                &construction_game_inst.game().pkgs[construction_edge.to()]
-                    .pkg
-                    .name
-            );
-
-            dbg!(
-                &assumption_game_inst.game().pkgs[*assumption_game_to]
-                    .pkg
-                    .name
-            );
             let edge_exists_in_assumption =
                 assumption_game_inst
                     .game()
                     .edges
                     .iter()
                     .any(|assumption_game_edge| {
+                        let constr_sig_fixed = construction_game_inst
+                            .instantiate_oracle_signature(construction_edge.sig().clone());
+                        let assump_sig_fixed = assumption_game_inst
+                            .instantiate_oracle_signature(assumption_game_edge.sig().clone());
+
                         assumption_game_edge.from() == *assump_src_pkg_inst_offs
                             && assumption_game_edge.to() == *assumption_game_to
-                            && construction_edge.sig() == assumption_game_edge.sig()
+                            && constr_sig_fixed == assump_sig_fixed
                     });
 
             if !edge_exists_in_assumption {

--- a/src/parser/reduction.rs
+++ b/src/parser/reduction.rs
@@ -188,6 +188,12 @@ fn compare_reduction(
                 // but let's play with the idea for a bit.
                 //
                 // Actually let's do that somewhere else.
+                //
+                // ----
+                //
+                // Alternative idea: rewrite during instantiation and put that piece of info
+                // somewhere. For some things we already do that, but these are just strings, not
+                // identifiers. maybe that is the actual problem. Let's try to change that
             });
         let right_edge = game_right
             .edges

--- a/src/parser/reduction.rs
+++ b/src/parser/reduction.rs
@@ -172,7 +172,23 @@ fn compare_reduction(
             .edges
             .iter()
             .find(|edge| edge.from() == inst_offs_left && edge.sig() == sig)
-            .unwrap();
+            .unwrap_or_else(|| {
+                let edge = game_left
+                    .edges
+                    .iter()
+                    .find(|edge| edge.from() == inst_offs_left && edge.sig().name == sig.name)
+                    .unwrap();
+
+                panic!("failed to find edge {edge:?} by comapring with signature {sig:?}");
+
+                // again, the problem is that there is a Bits(_) type in the signature.
+                // what is new is that we are on the level of proofs here, so we need another layer
+                // of instantiation here.
+                // Or we add a nestable EqWithContext somehow. I am not sure that is a good idea,
+                // but let's play with the idea for a bit.
+                //
+                // Actually let's do that somewhere else.
+            });
         let right_edge = game_right
             .edges
             .iter()

--- a/src/parser/tests/complete/mod.rs
+++ b/src/parser/tests/complete/mod.rs
@@ -266,7 +266,7 @@ fn game_const_rename() {
 
 #[test]
 fn proof_const_rename() {
-    let pkgs = packages::parse_files(&["KeyReal.pkg.ssp"]);
+    let pkgs = packages::parse_files(&["KeyRealMoreParams.pkg.ssp"]);
     let games = games::parse_files(&["ConstRename.ssp", "ConstRename2.ssp"], &pkgs);
 
     dbg!(&pkgs);

--- a/src/parser/tests/complete/mod.rs
+++ b/src/parser/tests/complete/mod.rs
@@ -255,6 +255,31 @@ fn package_empty_loop_works() {
     }
 }
 
+/// When instantiating a pacakge instance in a game, the name of the assigned constant must be
+/// allowed to be different from the parameter.
+///
+#[test]
+fn game_const_rename() {
+    let pkgs = packages::parse_files(&["KeyReal.pkg.ssp"]);
+    let game = games::parse_file("ConstRename.ssp", &pkgs);
+}
+
+#[test]
+fn proof_const_rename() {
+    let pkgs = packages::parse_files(&["KeyReal.pkg.ssp"]);
+    let games = games::parse_files(&["ConstRename.ssp", "ConstRename2.ssp"], &pkgs);
+
+    dbg!(&pkgs);
+    dbg!(&games);
+
+    let proof = proofs::parse(
+        &proofs::read_file("ConstRename.ssp"),
+        "ConstRename.ssp",
+        &pkgs,
+        &games,
+    );
+}
+
 /// This is a helper for transcripts. It can be cloned, and what is written in one clone can be
 /// read in all others. It is concurrency-safe. This can be passed into the Communicator, a simple
 /// `&mut Vec<u8>` can't. a `Vec<u8>` can, but then we lose access to it. This solves that problem.

--- a/src/parser/tests/complete/mod.rs
+++ b/src/parser/tests/complete/mod.rs
@@ -260,8 +260,8 @@ fn package_empty_loop_works() {
 ///
 #[test]
 fn game_const_rename() {
-    let pkgs = packages::parse_files(&["KeyReal.pkg.ssp"]);
-    let game = games::parse_file("ConstRename.ssp", &pkgs);
+    let pkgs = packages::parse_files(&["KeyRealMoreParams.pkg.ssp"]);
+    let games = games::parse_files(&["ConstRename.ssp", "ConstRename2.ssp"], &pkgs);
 }
 
 #[test]

--- a/src/parser/tests/games.rs
+++ b/src/parser/tests/games.rs
@@ -11,8 +11,14 @@ use crate::{
 
 pub fn parse(code: &str, name: &str, pkg_map: &HashMap<String, Package>) -> Composition {
     let mut game_pairs = SspParser::parse_composition(code).unwrap();
-    handle_composition(name, code, game_pairs.next().unwrap(), pkg_map)
-        .unwrap_or_else(|err| panic!("handle error for game in {name}: {err}", err = err))
+    handle_composition(name, code, game_pairs.next().unwrap(), pkg_map).unwrap_or_else(|err| {
+        let err_str = format!("{err:?}");
+        panic!(
+            "handle error for game in {name}:\n\t{err}\n\n{diag:?}",
+            err = err_str,
+            diag = miette::Report::new(err)
+        )
+    })
 }
 
 pub fn parse_fails(code: &str, name: &str, pkg_map: &HashMap<String, Package>) -> ParseGameError {

--- a/src/parser/tests/packages.rs
+++ b/src/parser/tests/packages.rs
@@ -17,7 +17,12 @@ pub fn parse(code: &str, file_name: &str) -> (String, Package) {
             err = err
         )
     });
-    handle_pkg(file_name, code, pkg_pairs.next().unwrap()).unwrap()
+    handle_pkg(file_name, code, pkg_pairs.next().unwrap())
+        .map_err(|err| {
+            println!("Error: {err:?}");
+            miette::Report::new(err)
+        })
+        .unwrap()
 }
 
 pub fn parse_fails(code: &str, name: &str) -> ParsePackageError {

--- a/src/parser/tests/sound/games.rs
+++ b/src/parser/tests/sound/games.rs
@@ -9,7 +9,7 @@ use crate::{
         package::ParseExpressionError,
         tests::{games, packages},
     },
-    types::Type,
+    types::{CountSpec, Type},
 };
 use std::{collections::HashMap, iter::FromIterator as _};
 
@@ -104,7 +104,9 @@ fn param_wrong_type() {
     };
 
     assert_eq!(err.expected, Type::Integer);
-    assert_eq!(err.got, Type::Bits("n".to_string()));
+    assert!(
+        matches!(&err.got, Type::Bits(countspec) if matches!(&**countspec, CountSpec::Identifier(ident) if ident.ident_ref() == "n"  ))
+    );
 }
 
 #[test]

--- a/src/parser/tests/sound/packages.rs
+++ b/src/parser/tests/sound/packages.rs
@@ -1,20 +1,21 @@
 use crate::{
     parser::{
+        common::HandleTypeError,
         error::{NoSuchTypeError, TypeMismatchError, UndefinedIdentifierError},
         package::{ParseExpressionError, ParsePackageError},
         tests::{packages, slice_source_span},
     },
-    types::Type,
+    types::{CountSpec, Type},
 };
 
 #[test]
 fn undefined_type_in_pkg_params() {
     let err = packages::parse_file_fails("bad_param_type.ssp");
     assert!(
-        matches!(err, ParsePackageError::NoSuchType(NoSuchTypeError {
+        matches!(err, ParsePackageError::HandleType(HandleTypeError::NoSuchType(NoSuchTypeError {
                 type_name,
                 ..
-            })
+            }))
             if &type_name == "ThisTypeDoesNotExist"
         )
     )
@@ -24,10 +25,10 @@ fn undefined_type_in_pkg_params() {
 fn undefined_type_in_pkg_state() {
     let err = packages::parse_file_fails("bad_state_type.ssp");
     assert!(
-        matches!(err, ParsePackageError::NoSuchType(NoSuchTypeError {
+        matches!(err, ParsePackageError::HandleType(HandleTypeError::NoSuchType(NoSuchTypeError {
                 type_name,
                 ..
-            })
+            }))
             if &type_name == "ThisTypeDoesNotExist"
         )
     )
@@ -189,18 +190,19 @@ fn bad_add_fails_4() {
 fn loop_start_non_integer_fails() {
     let err = packages::parse_file_fails("EmptyLoopStartNonIntegerFails.pkg.ssp");
 
-    assert!(
-        matches!(
+    assert!(matches!(
             &err,
             ParsePackageError::ParseExpression(ParseExpressionError::TypeMismatch(
                 TypeMismatchError {
                     expected: Type::Integer,
-                    got,
+                    got: Type::Bits(countspec),
                     ..
                 }
-            )) if got == &Type:: Bits("n".to_string())));
+            )) if matches!(&**countspec, CountSpec::Identifier(ident) if ident.ident_ref() == "n")));
+
     assert_eq!(
-        "type mismatch: got Bits(\"n\"), expected Integer",err.to_string()
+        "type mismatch: got Bits(\"n\"), expected Integer",
+        err.to_string()
     )
 }
 
@@ -208,17 +210,17 @@ fn loop_start_non_integer_fails() {
 fn loop_end_non_integer_fails() {
     let err = packages::parse_file_fails("EmptyLoopEndNonIntegerFails.pkg.ssp");
 
-    assert!(
-        matches!(
+    assert!(matches!(
             &err,
             ParsePackageError::ParseExpression(ParseExpressionError::TypeMismatch(
                 TypeMismatchError {
                     expected: Type::Integer,
-                    got,
+                    got: Type::Bits(countspec),
                     ..
                 }
-            )) if got == &Type:: Bits("n".to_string())));
+            )) if matches!(&**countspec, CountSpec::Identifier(ident) if ident.ident_ref() == "n")));
     assert_eq!(
-        "type mismatch: got Bits(\"n\"), expected Integer",err.to_string()
+        "type mismatch: got Bits(\"n\"), expected Integer",
+        err.to_string()
     )
 }

--- a/src/parser/tests/sound/packages.rs
+++ b/src/parser/tests/sound/packages.rs
@@ -199,11 +199,6 @@ fn loop_start_non_integer_fails() {
                     ..
                 }
             )) if matches!(&**countspec, CountSpec::Identifier(ident) if ident.ident_ref() == "n")));
-
-    assert_eq!(
-        "type mismatch: got Bits(\"n\"), expected Integer",
-        err.to_string()
-    )
 }
 
 #[test]
@@ -219,8 +214,4 @@ fn loop_end_non_integer_fails() {
                     ..
                 }
             )) if matches!(&**countspec, CountSpec::Identifier(ident) if ident.ident_ref() == "n")));
-    assert_eq!(
-        "type mismatch: got Bits(\"n\"), expected Integer",
-        err.to_string()
-    )
 }

--- a/src/parser/tests/sound/proofs.rs
+++ b/src/parser/tests/sound/proofs.rs
@@ -1,8 +1,9 @@
 use crate::parser::{
     error::{
         AssumptionExportsNotSufficientError, AssumptionMappingContainsDifferentPackagesError,
-        InconsistentReductions, ReductionPackageInstanceParameterMismatchError,
+        InconsistentReductions, ReductionPackageInstanceParameterMismatchError, TypeMismatchError,
     },
+    package::ParseExpressionError,
     proof::ParseProofError,
     tests::{games, packages, proofs, slice_source_span},
 };
@@ -418,7 +419,7 @@ fn fail_wrong_params_in_reduction_should_fail() {
 
     assert_eq!(left_pkg_inst_name, "enc");
     assert_eq!(right_pkg_inst_name, "enc");
-    assert_eq!(param_names, "m");
+    assert_eq!(param_names, "enc, m");
 
     let report = miette::Report::new(err);
     println!("the error prints like this:\n{:?}", report)

--- a/src/types.rs
+++ b/src/types.rs
@@ -22,36 +22,33 @@ pub enum Type {
 
 impl Type {
     pub(crate) fn rewrite(&self, rules: &[(Type, Type)]) -> Self {
-        match self {
-            Type::UserDefined(_) => {
-                if let Some((_, replace)) = rules.iter().find(|(search, _)| self == search) {
-                    replace.clone()
-                } else {
-                    self.clone()
+        if let Some((_, replace)) = rules.iter().find(|(search, _)| self == search) {
+            replace.clone()
+        } else {
+            match self {
+                Type::Empty
+                | Type::Integer
+                | Type::String
+                | Type::Boolean
+                | Type::Bits(_)
+                | Type::AddiGroupEl(_)
+                | Type::MultGroupEl(_) => self.clone(),
+
+                Type::List(t) => Type::List(Box::new(t.rewrite(rules))),
+                Type::Maybe(t) => Type::Maybe(Box::new(t.rewrite(rules))),
+                Type::Set(t) => Type::Set(Box::new(t.rewrite(rules))),
+
+                Type::Tuple(ts) => Type::Tuple(ts.iter().map(|t| t.rewrite(rules)).collect()),
+                Type::Table(t1, t2) => {
+                    Type::Table(Box::new(t1.rewrite(rules)), Box::new(t2.rewrite(rules)))
                 }
+                Type::Fn(ts, t) => Type::Fn(
+                    ts.iter().map(|t| t.rewrite(rules)).collect(),
+                    Box::new(t.rewrite(rules)),
+                ),
+                Type::Unknown => unreachable!(),
+                Type::UserDefined(_) => unreachable!(),
             }
-
-            Type::Empty
-            | Type::Integer
-            | Type::String
-            | Type::Boolean
-            | Type::Bits(_)
-            | Type::AddiGroupEl(_)
-            | Type::MultGroupEl(_) => self.clone(),
-
-            Type::List(t) => Type::List(Box::new(t.rewrite(rules))),
-            Type::Maybe(t) => Type::Maybe(Box::new(t.rewrite(rules))),
-            Type::Set(t) => Type::Set(Box::new(t.rewrite(rules))),
-
-            Type::Tuple(ts) => Type::Tuple(ts.iter().map(|t| t.rewrite(rules)).collect()),
-            Type::Table(t1, t2) => {
-                Type::Table(Box::new(t1.rewrite(rules)), Box::new(t2.rewrite(rules)))
-            }
-            Type::Fn(ts, t) => Type::Fn(
-                ts.iter().map(|t| t.rewrite(rules)).collect(),
-                Box::new(t.rewrite(rules)),
-            ),
-            Type::Unknown => unreachable!(),
         }
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,4 +1,4 @@
-use crate::expressions::Expression;
+use crate::identifier::Identifier;
 
 #[allow(dead_code)]
 #[derive(Debug, Clone, Eq, PartialEq, Hash, PartialOrd, Ord)]
@@ -8,9 +8,9 @@ pub enum Type {
     Integer,
     String,
     Boolean,
-    Bits(String),        // Bits strings of length ...
-    AddiGroupEl(String), // name of the group
-    MultGroupEl(String), // name of the group
+    Bits(Box<CountSpec>), // Bits strings of length ...
+    AddiGroupEl(String),  // name of the group
+    MultGroupEl(String),  // name of the group
     List(Box<Type>),
     Set(Box<Type>),
     Tuple(Vec<Type>),
@@ -21,7 +21,7 @@ pub enum Type {
 }
 
 impl Type {
-    pub(crate) fn rewrite(&self, rules: &[(Type, Type)]) -> Self {
+    pub(crate) fn rewrite_type(&self, rules: &[(Type, Type)]) -> Self {
         if let Some((_, replace)) = rules.iter().find(|(search, _)| self == search) {
             replace.clone()
         } else {
@@ -34,21 +34,30 @@ impl Type {
                 | Type::AddiGroupEl(_)
                 | Type::MultGroupEl(_) => self.clone(),
 
-                Type::List(t) => Type::List(Box::new(t.rewrite(rules))),
-                Type::Maybe(t) => Type::Maybe(Box::new(t.rewrite(rules))),
-                Type::Set(t) => Type::Set(Box::new(t.rewrite(rules))),
+                Type::List(t) => Type::List(Box::new(t.rewrite_type(rules))),
+                Type::Maybe(t) => Type::Maybe(Box::new(t.rewrite_type(rules))),
+                Type::Set(t) => Type::Set(Box::new(t.rewrite_type(rules))),
 
-                Type::Tuple(ts) => Type::Tuple(ts.iter().map(|t| t.rewrite(rules)).collect()),
-                Type::Table(t1, t2) => {
-                    Type::Table(Box::new(t1.rewrite(rules)), Box::new(t2.rewrite(rules)))
-                }
+                Type::Tuple(ts) => Type::Tuple(ts.iter().map(|t| t.rewrite_type(rules)).collect()),
+                Type::Table(t1, t2) => Type::Table(
+                    Box::new(t1.rewrite_type(rules)),
+                    Box::new(t2.rewrite_type(rules)),
+                ),
                 Type::Fn(ts, t) => Type::Fn(
-                    ts.iter().map(|t| t.rewrite(rules)).collect(),
-                    Box::new(t.rewrite(rules)),
+                    ts.iter().map(|t| t.rewrite_type(rules)).collect(),
+                    Box::new(t.rewrite_type(rules)),
                 ),
                 Type::Unknown => unreachable!(),
                 Type::UserDefined(_) => unreachable!(),
             }
         }
     }
+}
+
+/// Describes the length of Bits types
+#[derive(Debug, Clone, Eq, PartialEq, Hash, PartialOrd, Ord)]
+pub enum CountSpec {
+    Identifier(Identifier),
+    Literal(u64),
+    Any,
 }

--- a/src/writers/pseudocode/fmtwriter.rs
+++ b/src/writers/pseudocode/fmtwriter.rs
@@ -4,7 +4,7 @@ use crate::expressions::Expression;
 use crate::identifier::Identifier;
 use crate::package::{OracleDef, OracleSig, Package};
 use crate::statement::{CodeBlock, InvokeOracleStatement, Statement};
-use crate::types::Type;
+use crate::types::{CountSpec, Type};
 
 type Result = std::fmt::Result;
 
@@ -36,13 +36,26 @@ impl<W: Write> FmtWriter<W> {
 
         Ok(())
     }
+
+    pub fn write_countspec(&mut self, countspec: &CountSpec) -> Result {
+        match countspec {
+            CountSpec::Identifier(identifier) => self.write_string(identifier.ident_ref()),
+            CountSpec::Literal(num) => self.write_string(&format!("{num}")),
+            CountSpec::Any => self.write_string("*"),
+        }
+    }
+
     pub fn write_type(&mut self, t: &Type) -> Result {
         match t {
             Type::String => self.write_string("String"),
             Type::Integer => self.write_string("Integer"),
             Type::Boolean => self.write_string("Boolean"),
             Type::Empty => self.write_string("Empty"),
-            Type::Bits(n) => self.write_string(&format!("Bits({n})")),
+            Type::Bits(n) => {
+                self.write_string(&format!("Bits("))?;
+                self.write_string(&format!("&*n"))?;
+                self.write_string(&format!(")"))
+            }
             Type::Maybe(t) => {
                 self.write_string("Maybe(")?;
                 self.write_type(t)?;

--- a/src/writers/pseudocode/writer.rs
+++ b/src/writers/pseudocode/writer.rs
@@ -4,7 +4,7 @@ use crate::expressions::Expression;
 use crate::identifier::Identifier;
 use crate::package::{OracleDef, OracleSig, Package};
 use crate::statement::{CodeBlock, InvokeOracleStatement, Statement};
-use crate::types::Type;
+use crate::types::{CountSpec, Type};
 
 type Result = std::io::Result<()>;
 
@@ -31,13 +31,26 @@ impl<W: Write> Writer<W> {
 
         Ok(())
     }
+
+    pub fn write_countspec(&mut self, countspec: &CountSpec) -> Result {
+        match countspec {
+            CountSpec::Identifier(identifier) => self.write_string(identifier.ident_ref()),
+            CountSpec::Literal(num) => self.write_string(&format!("{num}")),
+            CountSpec::Any => self.write_string("*"),
+        }
+    }
+
     pub fn write_type(&mut self, t: &Type) -> Result {
         match t {
             Type::String => self.write_string("String"),
             Type::Integer => self.write_string("Integer"),
             Type::Boolean => self.write_string("Boolean"),
             Type::Empty => self.write_string("()"),
-            Type::Bits(n) => self.write_string(&format!("Bits({n})")),
+            Type::Bits(n) => {
+                self.write_string(&format!("Bits("))?;
+                self.write_string(&format!("&*n"))?;
+                self.write_string(&format!(")"))
+            }
             Type::Maybe(t) => {
                 self.write_string("Maybe(")?;
                 self.write_type(t)?;

--- a/src/writers/smt/contexts/game_inst.rs
+++ b/src/writers/smt/contexts/game_inst.rs
@@ -1,7 +1,7 @@
 use crate::{
     expressions::Expression,
     identifier::{game_ident::GameConstIdentifier, Identifier},
-    package::{Composition, Export, SplitExport},
+    package::{Composition, Export},
     proof::GameInstance,
     transforms::samplify::SampleInfo,
     types::Type,
@@ -16,7 +16,12 @@ use crate::{
     },
 };
 
-use super::{GameInstanceContext, OracleContext, PackageInstanceContext};
+use super::{OracleContext, PackageInstanceContext};
+
+#[derive(Clone, Debug, Copy)]
+pub struct GameInstanceContext<'a> {
+    game_inst: &'a GameInstance,
+}
 
 impl<'a> GameInstanceContext<'a> {
     pub(crate) fn new(game_inst: &'a GameInstance) -> Self {
@@ -291,10 +296,7 @@ impl<'a> GameInstanceContext<'a> {
             .pkgs // we only want a single package, no sorting needed
             .iter()
             .position(|pkg| pkg.name == inst_name)
-            .map(|inst_offs| PackageInstanceContext {
-                game_ctx: *self,
-                inst_offs,
-            })
+            .map(|inst_offs| PackageInstanceContext::new(*self, inst_offs))
     }
 
     pub(crate) fn pkg_inst_ctx_by_offs(
@@ -305,10 +307,7 @@ impl<'a> GameInstanceContext<'a> {
             return None;
         }
 
-        Some(PackageInstanceContext {
-            game_ctx: self,
-            inst_offs,
-        })
+        Some(PackageInstanceContext::new(self, inst_offs))
     }
 
     pub(crate) fn exported_oracle_ctx_by_name(
@@ -322,10 +321,7 @@ impl<'a> GameInstanceContext<'a> {
             .iter()
             .find(|Export(_, osig)| osig.name == oracle_name)?;
 
-        let inst_ctx = PackageInstanceContext {
-            game_ctx: *self,
-            inst_offs,
-        };
+        let inst_ctx = PackageInstanceContext::new(*self, inst_offs);
 
         inst_ctx.oracle_ctx_by_name(oracle_name)
     }

--- a/src/writers/smt/contexts/mod.rs
+++ b/src/writers/smt/contexts/mod.rs
@@ -1,5 +1,4 @@
 use crate::{
-    proof::GameInstance,
     transforms::samplify::SampleInfo,
     types::Type,
     writers::smt::{exprs::SmtExpr, names},
@@ -20,11 +19,6 @@ mod oracle;
 mod pkg_inst;
 //mod split_oracle;
 
-#[derive(Clone, Debug, Copy)]
-pub struct GameInstanceContext<'a> {
-    game_inst: &'a GameInstance,
-}
-
 // #[derive(Clone, Debug)]
 // pub struct SplitOracleContext<'a> {
 //     game_inst_context: GameInstanceContext<'a>,
@@ -33,18 +27,9 @@ pub struct GameInstanceContext<'a> {
 //     partials: &'a PartialsDatatype,
 // }
 
-#[derive(Copy, Clone, Debug)]
-pub struct OracleContext<'a> {
-    game_inst_context: GameInstanceContext<'a>,
-    pkg_inst_offs: usize,
-    oracle_offs: usize,
-}
-
-#[derive(Clone, Debug, Copy)]
-pub struct PackageInstanceContext<'a> {
-    game_ctx: GameInstanceContext<'a>,
-    inst_offs: usize,
-}
+pub use game_inst::GameInstanceContext;
+pub use oracle::OracleContext;
+pub use pkg_inst::PackageInstanceContext;
 
 pub trait GenericOracleContext<'a> {
     fn game_inst_ctx(&self) -> GameInstanceContext<'a>;

--- a/src/writers/smt/exprs.rs
+++ b/src/writers/smt/exprs.rs
@@ -233,8 +233,13 @@ impl From<Type> for SmtExpr {
     fn from(t: Type) -> SmtExpr {
         match t {
             Type::Bits(length) => {
-                // TODO make sure we define this somewhere
-                SmtExpr::Atom(format!("Bits_{}", length))
+                let length = match &*length {
+                    crate::types::CountSpec::Identifier(identifier) => identifier.ident(),
+                    crate::types::CountSpec::Literal(num) => format!("{num}"),
+                    crate::types::CountSpec::Any => "*".to_string(),
+                };
+
+                SmtExpr::Atom(format!("Bits_{length}"))
             }
             Type::Maybe(t) => SmtExpr::List(vec![SmtExpr::Atom("Maybe".into()), (*t).into()]),
             Type::Boolean => SmtExpr::Atom("Bool".to_string()),
@@ -263,8 +268,13 @@ impl From<&Type> for SmtExpr {
     fn from(t: &Type) -> SmtExpr {
         match t {
             Type::Bits(length) => {
-                // TODO make sure we define this somewhere
-                SmtExpr::Atom(format!("Bits_{}", length))
+                let length = match &**length {
+                    crate::types::CountSpec::Identifier(identifier) => identifier.ident(),
+                    crate::types::CountSpec::Literal(num) => format!("{num}"),
+                    crate::types::CountSpec::Any => "*".to_string(),
+                };
+
+                SmtExpr::Atom(format!("Bits_{length}"))
             }
             Type::Maybe(t) => SmtExpr::List(vec![SmtExpr::Atom("Maybe".into()), (&**t).into()]),
             Type::Boolean => SmtExpr::Atom("Bool".to_string()),

--- a/src/writers/smt/sorts.rs
+++ b/src/writers/smt/sorts.rs
@@ -30,7 +30,14 @@ impl From<&Type> for SmtlibSort {
             Type::Integer => theories::ints::int(),
             Type::String => "String".into(),
             Type::Boolean => theories::core::bool_(),
-            Type::Bits(name) => format!("Bits_{name}").into(),
+            Type::Bits(length) => {
+                let length = match &**length {
+                    crate::types::CountSpec::Identifier(identifier) => identifier.ident(),
+                    crate::types::CountSpec::Literal(num) => format!("{num}"),
+                    crate::types::CountSpec::Any => "*".to_string(),
+                };
+                format!("Bits_{length}").into()
+            }
             Type::Table(ty_idx, ty_val) => SmtlibSort {
                 name: "Array".into(),
                 parameters: vec![
@@ -80,8 +87,13 @@ impl From<Type> for Sort {
     fn from(value: Type) -> Self {
         match value {
             Type::Bits(length) => {
-                // TODO make sure we define this somewhere
-                Sort::Other(format!("Bits_{}", length), vec![])
+                let length = match &*length {
+                    crate::types::CountSpec::Identifier(identifier) => identifier.ident(),
+                    crate::types::CountSpec::Literal(num) => format!("{num}"),
+                    crate::types::CountSpec::Any => "*".to_string(),
+                };
+
+                Sort::Other(format!("Bits_{length}"), vec![])
             }
             Type::Maybe(t) => Sort::Other("Maybe".to_string(), vec![(*t).into()]),
             Type::Boolean => Sort::Bool,

--- a/src/writers/smt/tests/mod.rs
+++ b/src/writers/smt/tests/mod.rs
@@ -162,8 +162,7 @@ fn test_const_datatypes_remap_consts() {
     let bindings = &mapping.body.bindings;
 
     println!("bindings: {bindings:?}");
-    assert_eq!(bindings.len(), 1);
-    assert_eq!(bindings[0].0, "m");
+    assert!(bindings.is_empty());
 
     let constructor = &mapping.body.body;
     println!("body: {:?}", mapping.body.body);
@@ -173,7 +172,7 @@ fn test_const_datatypes_remap_consts() {
 
     assert_eq!(constructor_list.len(), 2);
     assert_eq!(constructor_list[0].to_string(), "<mk-pkg-consts-TinyPkg>");
-    assert_eq!(constructor_list[1].to_string(), "(+ m 1)\n");
+    assert_eq!(constructor_list[1].to_string(), "1");
 }
 
 #[test]

--- a/src/writers/tex/writer.rs
+++ b/src/writers/tex/writer.rs
@@ -14,6 +14,7 @@ use crate::parser::package::ForComp;
 use crate::parser::reduction::NewReductionMappingEntry;
 use crate::proof::Proof;
 use crate::statement::{CodeBlock, InvokeOracleStatement, Statement};
+use crate::types::CountSpec;
 use crate::types::Type;
 use crate::util::prover_process::ProverBackend;
 use crate::util::prover_process::{Communicator, ProverResponse};
@@ -43,9 +44,17 @@ impl<'a> BlockWriter<'a> {
         format!("\\n{{{}}}", ident.ident().replace('_', "\\_"))
     }
 
+    fn countspec_to_tex(&self, count_spec: &CountSpec) -> String {
+        match count_spec {
+            CountSpec::Identifier(identifier) => identifier.ident(),
+            CountSpec::Literal(num) => format!("{num}"),
+            CountSpec::Any => "*".to_string(),
+        }
+    }
+
     fn type_to_tex(&self, tipe: &Type) -> String {
         match tipe {
-            Type::Bits(n) => format!("\\bin^{{{}}}", n),
+            Type::Bits(n) => format!("\\bin^{{{}}}", self.countspec_to_tex(&*n)),
             _ => format!("\\O{{{:?}}}", tipe),
         }
     }
@@ -405,9 +414,7 @@ pub fn tex_write_oracle(
             .sig
             .args
             .iter()
-            .map(|(a, _)| {
-                format!("\\n{{{}}}", a.replace("_", "\\_"))
-            })
+            .map(|(a, _)| { format!("\\n{{{}}}", a.replace("_", "\\_")) })
             .collect::<Vec<_>>()
             .join(", ")
     )?;
@@ -490,7 +497,7 @@ fn tex_solve_composition_graph(
     let mut model = String::new();
     let write_model = |comm: &mut crate::util::prover_process::Communicator| {
         let mut edges: HashSet<(usize, usize)> = HashSet::new();
-        
+
         writeln!(comm, "(declare-const num-pkgs Int)").unwrap();
         writeln!(comm, "(declare-const width Int)").unwrap();
         writeln!(comm, "(declare-const height Int)").unwrap();
@@ -615,7 +622,7 @@ fn tex_solve_composition_graph(
             break;
         }
     }
-    
+
     for height in 2..50 {
         let mut comm = Communicator::new(backend.unwrap()).unwrap();
 

--- a/testdata/ssp-code/games/ConstRename.ssp
+++ b/testdata/ssp-code/games/ConstRename.ssp
@@ -1,9 +1,11 @@
 composition ConstRenameGame {
     const m: Integer;
+    const lala: Bits(m);
     
-    instance key = KeyReal {
+    instance key = KeyRealMoreParams {
         params {
             n: m,
+            zeron: lala,
         }
     }
     

--- a/testdata/ssp-code/games/ConstRename.ssp
+++ b/testdata/ssp-code/games/ConstRename.ssp
@@ -1,0 +1,17 @@
+composition ConstRenameGame {
+    const m: Integer;
+    
+    instance key = KeyReal {
+        params {
+            n: m,
+        }
+    }
+    
+    compose {
+        adversary: {
+            Set: key,
+            Get: key,
+        },
+    }
+}
+

--- a/testdata/ssp-code/games/ConstRename2.ssp
+++ b/testdata/ssp-code/games/ConstRename2.ssp
@@ -1,9 +1,11 @@
 composition ConstRenameGame2 {
     const l: Integer;
+    const oho: Bits(l);
     
-    instance key = KeyReal {
+    instance key = KeyRealMoreParams {
         params {
             n: l,
+            zeron: oho
         }
     }
     

--- a/testdata/ssp-code/games/ConstRename2.ssp
+++ b/testdata/ssp-code/games/ConstRename2.ssp
@@ -1,0 +1,17 @@
+composition ConstRenameGame2 {
+    const l: Integer;
+    
+    instance key = KeyReal {
+        params {
+            n: l,
+        }
+    }
+    
+    compose {
+        adversary: {
+            Set: key,
+            Get: key,
+        },
+    }
+}
+

--- a/testdata/ssp-code/games/Game-instantiating-with-literal-works.comp.ssp
+++ b/testdata/ssp-code/games/Game-instantiating-with-literal-works.comp.ssp
@@ -1,7 +1,7 @@
 composition ConstructionReal {
     const n: Integer;
     const m: Integer;
-    const prf: fn Bits(n), Bits(n) -> Bits(n);
+    const prf: fn Bits(1), Bits(1) -> Bits(1);
     const enc: fn Bits(n), Bits(n), Bits(n) -> Bits(m);
     
     instance prf = PRF {

--- a/testdata/ssp-code/games/small_remap_consts.ssp
+++ b/testdata/ssp-code/games/small_remap_consts.ssp
@@ -1,9 +1,7 @@
 composition SmallGame {
-    const m: Integer;
-
     instance tiny_instance  = TinyPkg {
         params {
-            n: (m + 1),
+            n: 1,
         }
     }
 

--- a/testdata/ssp-code/packages/KeyRealMoreParams.pkg.ssp
+++ b/testdata/ssp-code/packages/KeyRealMoreParams.pkg.ssp
@@ -1,0 +1,20 @@
+package KeyRealMoreParams {
+    params {
+        n: Integer,
+        zeron: Bits(n),
+    }
+    
+    state {
+        K: Table(Bits(n), Bits(n)),
+    }
+
+    oracle Get(h: Bits(n)) -> Bits(n) {
+        return Unwrap(K[h]);
+    }
+    
+    oracle Set(k: Bits(n), h: Bits(n))  {
+        if (K[h] == None) {
+            K[h] <- Some(k);
+        }
+    }
+}

--- a/testdata/ssp-code/proofs/ConstRename.ssp
+++ b/testdata/ssp-code/proofs/ConstRename.ssp
@@ -12,14 +12,14 @@ proof ConstRenameProof {
   instance const_rename_assumption_right = ConstRenameGame2 {
       params {
           l: o,
-          lala: zeroo,
+          oho: zeroo,
       }
   }
 
   instance const_rename_construction_left = ConstRenameGame {
       params {
           m: o,
-          oho: zeroo,
+          lala: zeroo,
       }
   }
 

--- a/testdata/ssp-code/proofs/ConstRename.ssp
+++ b/testdata/ssp-code/proofs/ConstRename.ssp
@@ -1,0 +1,47 @@
+proof ConstRenameProof {
+  const o: Integer;
+
+  instance const_rename_assumption_left = ConstRenameGame {
+      params {
+          m: o,
+      }
+  }
+
+  instance const_rename_assumption_right = ConstRenameGame2 {
+      params {
+          l: o,
+      }
+  }
+
+  instance const_rename_construction_left = ConstRenameGame {
+      params {
+          m: o,
+      }
+  }
+
+  instance const_rename_construction_right = ConstRenameGame2 {
+      params {
+          l: o,
+      }
+  }
+
+  assumptions {
+    Test: const_rename_assumption_left ~ const_rename_assumption_right
+  }
+
+
+  gamehops {
+    reduction const_rename_construction_left const_rename_construction_right {
+      assumption Test
+
+      map const_rename_assumption_left const_rename_construction_left {
+          key: key
+      }
+
+      map const_rename_assumption_right const_rename_construction_right {
+          key: key
+      }
+    }
+  }
+}
+

--- a/testdata/ssp-code/proofs/ConstRename.ssp
+++ b/testdata/ssp-code/proofs/ConstRename.ssp
@@ -1,27 +1,32 @@
 proof ConstRenameProof {
   const o: Integer;
+  const zeroo: Bits(o);
 
   instance const_rename_assumption_left = ConstRenameGame {
       params {
           m: o,
+          lala: zeroo,
       }
   }
 
   instance const_rename_assumption_right = ConstRenameGame2 {
       params {
           l: o,
+          lala: zeroo,
       }
   }
 
   instance const_rename_construction_left = ConstRenameGame {
       params {
           m: o,
+          oho: zeroo,
       }
   }
 
   instance const_rename_construction_right = ConstRenameGame2 {
       params {
           l: o,
+          oho: zeroo,
       }
   }
 

--- a/testdata/ssp-code/proofs/reduction-wrong-package-params-should-fail.ssp
+++ b/testdata/ssp-code/proofs/reduction-wrong-package-params-should-fail.ssp
@@ -4,14 +4,14 @@ proof PRF {
     const p: Integer;
     const prf: fn Bits(n),Bits(n) -> Bits(n);
     const enc: fn Bits(n),Bits(n),Bits(n) -> Bits(m);
+    const encp: fn Bits(n),Bits(n),Bits(n) -> Bits(p);
 
     instance constructionreal = ConstructionReal {
         params {
             n: n,
             m: p,
             prf: prf,
-            enc: enc,
-
+            enc: encp,
         }
     }
 


### PR DESCRIPTION
When instantiating a package with Type::Bits in a game, we didn't compare the correct strings of the Bits.

Let's say we have a package with parameters `n: Int` and `k: Bits(n)`, and a game  with consts `m: Int` and `k: Bits(m)`, and int instantiates the package using `n: m` and `k: k`, then so far the type checker compared `Type::Bits("m") with `Type::Bits("n")`, which failed.

Conversely, if we had the same package and a game with constants `n: Int`, `m: Int`, `k: Bits(n)`, and we instantiated the package `n: m`, `k: k`, the typechecker would fail to identify that there was an issue.

So far we added tests for the first scenario, but not the latter. In fact, the latter turned up in the code a few times and we had to fix these tests as well.