### PR TITLE
Walk subdirectories when loading project files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -555,6 +555,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -629,6 +638,7 @@ dependencies = [
  "subprocess",
  "tempfile",
  "thiserror 1.0.61",
+ "walkdir",
 ]
 
 [[package]]
@@ -800,6 +810,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -814,6 +834,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+dependencies = [
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,3 +38,4 @@ miette = { version = "7.2.0", features = ["fancy"] }
 tempfile = "3"
 sspverif-smtlib = { workspace = true }
 log = "0.4.22"
+walkdir = "2"

--- a/src/project/mod.rs
+++ b/src/project/mod.rs
@@ -8,6 +8,7 @@
 use std::io::ErrorKind;
 use std::path::Path;
 use std::{collections::HashMap, path::PathBuf};
+use walkdir;
 
 use error::{Error, Result};
 
@@ -46,9 +47,8 @@ pub struct Files {
 impl Files {
     pub fn load(root: &Path) -> Result<Self> {
         fn load_files(path: impl AsRef<Path>) -> Result<Vec<(String, String)>> {
-            std::fs::read_dir(path.as_ref())?
+            walkdir::WalkDir::new(path.as_ref()).into_iter().filter_map(|e| e.ok())
                 .map(|dir_entry| {
-                    let dir_entry = dir_entry?;
                     let file_name = dir_entry.file_name();
                     let Some(file_name) = file_name.to_str() else {
                         return Ok(None);


### PR DESCRIPTION
This change recursively walk subdirectories when loading project files. Feature was motivated by the TLS 1.3 key schedule security project in which we have automated generation of packages based on some templates and to nicely organize packages, we want autogenerated ones to be in their own subdirectory.