### PR TITLE
Print proper error when not in project

### DIFF
--- a/src/project/error.rs
+++ b/src/project/error.rs
@@ -3,13 +3,15 @@ use miette::Diagnostic;
 use std::io::Error as IOError;
 use thiserror::Error;
 
+use super::FindProjectRootError;
+
 #[derive(Debug, Error, Diagnostic)]
 pub enum Error {
-    #[error("error showing equivalence: {0}")]
+    #[error("error showing equivalence")]
     EquivalenceError(#[from] crate::gamehops::equivalence::error::Error),
     #[error("consistency check failed with {0}")]
     ProofCheck(String),
-    #[error("io error: {0}")]
+    #[error("io error")]
     IOError(#[from] IOError),
     #[error("package {0} defined in both {1} and {2}")]
     RedefinedPackage(String, String, String),
@@ -17,16 +19,18 @@ pub enum Error {
     RedefinedGame(String, String, String),
     #[error("proof {0} defined in both {1} and {2}")]
     RedefinedProof(String, String, String),
-    #[error("error parsing utf-8: {0}")]
+    #[error("error parsing utf-8")]
     FromUtf8Error(#[from] std::string::FromUtf8Error),
-    #[error("error in interaction with child process: {0}")]
+    #[error("error in interaction with child process")]
     ChildProcessInteractionError(#[from] expectrl::Error),
-    #[error("error interactiv with prover process: {0}")]
+    #[error("error interactiv with prover process")]
     ProcessError(#[from] crate::util::process::Error),
-    #[error("error interactiv with prover process: {0}")]
+    #[error("error interactiv with prover process")]
     ProverProcessError(#[from] crate::util::prover_process::Error),
     //#[error("got a formatting error")]
     //FmtError(#[from] std::fmt::Error),
+    #[error("error finding project root")]
+    FindProjectRoot(#[from] FindProjectRootError),
 
     // confirmed needed errors are below:
     #[error("syntax error: {0} at {1:?} / {2:?}")]

--- a/src/project/mod.rs
+++ b/src/project/mod.rs
@@ -379,15 +379,11 @@ pub fn find_project_root() -> std::result::Result<std::path::PathBuf, FindProjec
         }
 
         match dir.parent() {
-            None => return Err(NotInProjectError.into()),
+            None => return Err(FindProjectRootError::NotInProject),
             Some(parent) => dir = parent.into(),
         }
     }
 }
-
-#[derive(Debug, thiserror::Error)]
-#[error("Not in project: no ssp.toml file in this or any parent directory")]
-pub struct NotInProjectError;
 
 #[derive(Debug, thiserror::Error)]
 pub enum FindProjectRootError {
@@ -395,6 +391,6 @@ pub enum FindProjectRootError {
     CurrentDir(std::io::Error),
     #[error("Error reading directory:")]
     ReadDir(std::io::Error),
-    #[error(transparent)]
-    NotInProject(#[from] NotInProjectError),
+    #[error("Not in project: no ssp.toml file in this or any parent directory")]
+    NotInProject,
 }

--- a/src/project/mod.rs
+++ b/src/project/mod.rs
@@ -1,3 +1,4 @@
+use miette::Diagnostic;
 /**
  *  project is the high-level structure of sspverif.
  *
@@ -47,7 +48,9 @@ pub struct Files {
 impl Files {
     pub fn load(root: &Path) -> Result<Self> {
         fn load_files(path: impl AsRef<Path>) -> Result<Vec<(String, String)>> {
-            walkdir::WalkDir::new(path.as_ref()).into_iter().filter_map(|e| e.ok())
+            walkdir::WalkDir::new(path.as_ref())
+                .into_iter()
+                .filter_map(|e| e.ok())
                 .map(|dir_entry| {
                     let file_name = dir_entry.file_name();
                     let Some(file_name) = file_name.to_str() else {
@@ -359,13 +362,13 @@ impl<'a> Project<'a> {
     }
 }
 
-pub fn find_project_root() -> std::io::Result<std::path::PathBuf> {
-    let mut dir = std::env::current_dir()?;
+pub fn find_project_root() -> std::result::Result<std::path::PathBuf, FindProjectRootError> {
+    let mut dir = std::env::current_dir().map_err(FindProjectRootError::CurrentDir)?;
 
     loop {
-        let lst = dir.read_dir()?;
+        let lst = dir.read_dir().map_err(FindProjectRootError::ReadDir)?;
         for entry in lst {
-            let entry = entry?;
+            let entry = entry.map_err(FindProjectRootError::ReadDir)?;
             let file_name = match entry.file_name().into_string() {
                 Err(_) => continue,
                 Ok(name) => name,
@@ -376,8 +379,22 @@ pub fn find_project_root() -> std::io::Result<std::path::PathBuf> {
         }
 
         match dir.parent() {
-            None => return Err(std::io::Error::from(ErrorKind::NotFound)),
+            None => return Err(NotInProjectError.into()),
             Some(parent) => dir = parent.into(),
         }
     }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("Not in project: no ssp.toml file in this or any parent directory")]
+pub struct NotInProjectError;
+
+#[derive(Debug, thiserror::Error)]
+pub enum FindProjectRootError {
+    #[error("Error determining current directory:")]
+    CurrentDir(std::io::Error),
+    #[error("Error reading directory:")]
+    ReadDir(std::io::Error),
+    #[error(transparent)]
+    NotInProject(#[from] NotInProjectError),
 }


### PR DESCRIPTION
So far, when calling `ssbee prove` in a directory that is not a project or a subdirectory of a project, we would print a cryptic error. This finally lets the user know that they are not in a project.

Fixes #57