### PR TITLE
Prevent sat check to wait indefinitely if smt file ends in comments

### DIFF
--- a/src/util/prover_process.rs
+++ b/src/util/prover_process.rs
@@ -206,7 +206,7 @@ impl Communicator {
 
     #[cfg(not(target_os = "windows"))]
     pub fn check_sat(&mut self) -> Result<ProverResponse> {
-        writeln!(self, "(check-sat)")?;
+        writeln!(self, "\n(check-sat)")?;
 
         let pred =
             |_: usize, data: &str| -> (usize, Option<result::Result<ProverResponse, Error>>) {
@@ -231,7 +231,7 @@ impl Communicator {
 
     #[cfg(target_os = "windows")]
     pub fn check_sat(&mut self) -> Result<ProverResponse> {
-        writeln!(self, "(check-sat)")?;
+        writeln!(self, "\n(check-sat)")?;
 
         let pred =
             |_: usize, data: &str| -> (usize, Option<result::Result<ProverResponse, Error>>) {


### PR DESCRIPTION
This change prevents the sat check to wait indefinitely if the SMT file ends in comments and as a result the "(check-sat)" will be part of the comments.