### PR TITLE
Fix randomness mapping when mapping makes claims about invalid IDs

### DIFF
--- a/src/gamehops/equivalence/mod.rs
+++ b/src/gamehops/equivalence/mod.rs
@@ -1658,7 +1658,7 @@ impl<'a> EquivalenceContext<'a> {
                 .push(pos);
         }
 
-        let mut body: SmtExpr = false.into();
+        let mut body: SmtExpr = true.into();
 
         for tipe in types {
             let sort: SmtExpr = tipe.into();


### PR DESCRIPTION
When the randomness mapping makes claims about invalid sample ids (like if id left and right is equal), the current implementation will have an unsatisfiable mapping.

Change rand-is-eq to accept invalid sample ids instead of rejecting