### PR TITLE
refine `ssbee prove` -- allow checking one specific oracle

### DIFF
--- a/crates/ssbee/src/main.rs
+++ b/crates/ssbee/src/main.rs
@@ -178,6 +178,8 @@ struct Prove {
     proofstep: Option<usize>,
     #[clap(long)]
     proof: Option<String>,
+    #[clap(long)]
+    oracle: Option<String>,
 }
 
 #[derive(clap::Args, Debug)]
@@ -204,7 +206,7 @@ fn prove(p: &Prove) -> Result<(), project::error::Error> {
 
     assert!(p.proofstep == None || p.proof != None);
 
-    project.prove(p.prover, p.transcript, &p.proof, p.proofstep)
+    project.prove(p.prover, p.transcript, &p.proof, p.proofstep, &p.oracle)
 }
 
 fn explain(_game_name: &str, _dst: &Option<String>) -> Result<(), project::error::Error> {

--- a/src/gamehops/equivalence/verify_fn.rs
+++ b/src/gamehops/equivalence/verify_fn.rs
@@ -14,7 +14,7 @@ use crate::{
 
 use super::EquivalenceContext;
 
-pub fn verify(eq: &Equivalence, proof: &Proof, mut prover: Communicator) -> Result<()> {
+pub fn verify(eq: &Equivalence, proof: &Proof, mut prover: Communicator, req_oracle: &Option<String>) -> Result<()> {
     let (proof, auxs) = EquivalenceTransform.transform_proof(proof).unwrap();
 
     let eqctx = EquivalenceContext {
@@ -37,6 +37,11 @@ pub fn verify(eq: &Equivalence, proof: &Proof, mut prover: Communicator) -> Resu
     eqctx.emit_constant_declarations(&mut prover)?;
 
     for oracle_sig in eqctx.oracle_sequence() {
+        if let Some(ref req_oracle) = req_oracle {
+            if *req_oracle != oracle_sig.name {
+                continue;
+            }
+        }
         println!("verify: oracle:{oracle_sig:?}");
         write!(prover, "(push 1)").unwrap();
         eqctx.emit_return_value_helpers(&mut prover, &oracle_sig.name)?;

--- a/src/parser/tests/complete/mod.rs
+++ b/src/parser/tests/complete/mod.rs
@@ -194,7 +194,7 @@ fn equivalence_gamehome_generates_code() {
     let backend = ProverBackend::Cvc5;
     let transcript = SharedVecWriter::default();
     let prover = Communicator::new_with_transcript(backend, transcript.clone()).unwrap();
-    equivalence::verify(eq, &proof, prover).unwrap_or_else(|err| {
+    equivalence::verify(eq, &proof, prover, &None).unwrap_or_else(|err| {
         panic!(
             "got error {err}.\n\ntranscript:\n{transcript}",
             err = err,

--- a/src/project/mod.rs
+++ b/src/project/mod.rs
@@ -194,6 +194,7 @@ impl<'a> Project<'a> {
         transcript: bool,
         req_proof: &Option<String>,
         req_proofstep: Option<usize>,
+        req_oracle: &Option<String>,
     ) -> Result<()> {
         let mut proof_keys: Vec<_> = self.proofs.keys().collect();
         proof_keys.sort();
@@ -222,7 +223,7 @@ impl<'a> Project<'a> {
                         } else {
                             Communicator::new(backend)?
                         };
-                        equivalence::verify(eq, proof, prover)?;
+                        equivalence::verify(eq, proof, prover, &req_oracle)?;
                     }
                 }
 


### PR DESCRIPTION
This really becomes useful when writing complicated proves where verifying an oracle can take minutes. Current best method is changing the order in which oracles are exposed to the adversary in the left composition, now one can ask for verification of a specific oracle.