### PR TITLE
set up env_logger and replace println!s by log messages

### DIFF
--- a/crates/ssbee/Cargo.toml
+++ b/crates/ssbee/Cargo.toml
@@ -7,3 +7,4 @@ edition.workspace = true
 sspverif = { workspace = true }
 clap = { version = "4.0", features = ["derive"] }
 miette = { version = "7.2.0", features = ["fancy"] }
+env_logger = "0.11"

--- a/crates/ssbee/src/main.rs
+++ b/crates/ssbee/src/main.rs
@@ -112,6 +112,7 @@ This would be the contents is JSONy notation. We'll see how that looks like in t
 
 */
 use clap::{Parser, Subcommand};
+use env_logger::Logger;
 use sspverif::project;
 use sspverif::util::prover_process::ProverBackend;
 
@@ -250,6 +251,7 @@ fn wire_check(game_name: &str, dst_idx: usize) -> Result<(), project::error::Err
 }
 
 fn main() -> miette::Result<()> {
+    env_logger::init();
     let cli = Cli::parse();
 
     let result = match &cli.command {

--- a/src/gamehops/equivalence/mod.rs
+++ b/src/gamehops/equivalence/mod.rs
@@ -173,7 +173,7 @@ impl<'a> EquivalenceContext<'a> {
                                 Some(Expression::Identifier(ident@Identifier::ProofIdentifier(ProofIdentifier::Const(_)))) => ident.ident(),
                                 Some(Expression::Identifier(_)) => unreachable!("other identifiers can't occur here"),
                                 Some(other) => todo!("ADD ERR MSG: no complex expressions allowed for now, found {other:?}"),
-                                None => {println!("skipping identifier {id:?} since it is not fully resolved"); ident.ident()}
+                                None => {log::debug!("skipping identifier {id:?} since it is not fully resolved"); ident.ident()}
                             }
                         } ,
                         Identifier::PackageIdentifier(PackageIdentifier::Const(pkg_const_ident)) => match pkg_const_ident.game_assignment.as_ref().unwrap_or_else(|| panic!("the assigned value for this identifier should have been resolved at this point:\n  {pkg_const_ident:#?}")).as_ref() {
@@ -182,7 +182,7 @@ impl<'a> EquivalenceContext<'a> {
                                     Some(Expression::Identifier(ident@Identifier::ProofIdentifier(ProofIdentifier::Const(_))) )=> ident.ident(),
                                     Some(Expression::Identifier(_) )=> unreachable!("other identifiers can't occur here"),
                                     Some(other) => todo!("ADD ERR MSG: no complex expressions allowed for now, found {other:?}"),
-                                    None => {println!("skipping identifier {id:?} since it is not fully resolved"); ident.ident()}
+                                    None => {log::debug!("skipping identifier {id:?} since it is not fully resolved"); ident.ident()}
                                 }
                             },
                             Expression::Identifier(_) => unreachable!("other identifiers can't occur here"),
@@ -762,14 +762,14 @@ impl<'a> EquivalenceContext<'a> {
 
     fn emit_invariant(&self, comm: &mut Communicator, oracle_name: &str) -> Result<()> {
         for file_name in &self.equivalence.invariants_by_oracle_name(oracle_name) {
-            println!("reading file {file_name}");
+            log::info!("reading file {file_name}");
             let file_contents = std::fs::read_to_string(file_name).map_err(|err| {
                 let file_name = file_name.clone();
                 error::new_invariant_file_read_error(oracle_name.to_string(), file_name, err)
             })?;
-            println!("read file {file_name}");
+            log::info!("read file {file_name}");
             write!(comm, "{file_contents}").unwrap();
-            println!("wrote contents of file {file_name}");
+            log::info!("wrote contents of file {file_name}");
 
             if comm.check_sat()? != ProverResponse::Sat {
                 return Err(Error::UnsatAfterInvariantRead {
@@ -1314,7 +1314,7 @@ impl<'a> EquivalenceContext<'a> {
             .find_game_instance(self.equivalence().left_name())
             .unwrap();
 
-        println!("oracle sequence: {:?}", game_inst.game().exports);
+        log::debug!("oracle sequence: {:?}", game_inst.game().exports);
 
         game_inst
             .game()

--- a/src/gamehops/equivalence/verify_fn.rs
+++ b/src/gamehops/equivalence/verify_fn.rs
@@ -42,7 +42,7 @@ pub fn verify(eq: &Equivalence, proof: &Proof, mut prover: Communicator, req_ora
                 continue;
             }
         }
-        println!("verify: oracle:{oracle_sig:?}");
+        log::info!("verify: oracle:{oracle_sig:?}");
         write!(prover, "(push 1)").unwrap();
         eqctx.emit_return_value_helpers(&mut prover, &oracle_sig.name)?;
         eqctx.emit_invariant(&mut prover, &oracle_sig.name)?;

--- a/src/writers/smt/writer.rs
+++ b/src/writers/smt/writer.rs
@@ -1008,7 +1008,7 @@ impl<'a> CompositionSmtWriter<'a> {
             body: const_bindwrapped,
         };
 
-        println!("pkg inst params: {:?}", &inst.params);
+        log::debug!("pkg inst params: {:?}", &inst.params);
 
         octx.oracle_pattern().define_fun(state_bindwrapped).into()
     }


### PR DESCRIPTION
this sets up a very unconfigured env_logger.

set `RUST_LOG=debug` to see all println messages that were there before. This also very compatible with #114 via `indicatif_log_bridge`

