### PR TITLE
License the code as MIT OR Apache-2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [".", "crates/smtlib", "crates/domino"]
 version = "0.1.0"
 edition = "2021"
 readme = "Readme.md"
+license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]
 sspverif-smtlib = { path = "crates/smtlib" }

--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2021-2025 The Domino Team
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,0 +1,27 @@
+MIT License
+
+Copyright (c) 2021-2025 The Domino Team
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/crates/domino/build.rs
+++ b/crates/domino/build.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use clap::{CommandFactory, ValueEnum};
 use clap_complete::{generate_to, Shell};
 use std::env;

--- a/crates/domino/src/cli.rs
+++ b/crates/domino/src/cli.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use clap::{Parser, Subcommand};
 use sspverif::util::prover_process::ProverBackend;
 

--- a/crates/domino/src/main.rs
+++ b/crates/domino/src/main.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 /*
 
 What is the functionality of the tool:

--- a/crates/smtlib/src/lib.rs
+++ b/crates/smtlib/src/lib.rs
@@ -1,2 +1,4 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 pub mod syntax;
 pub mod theories;

--- a/crates/smtlib/src/syntax.rs
+++ b/crates/smtlib/src/syntax.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 pub mod tokens;
 
 pub mod s_expr;

--- a/crates/smtlib/src/syntax/attribute.rs
+++ b/crates/smtlib/src/syntax/attribute.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use super::{
     s_expr::{SExpr, SpecConstant},
     tokens::{Keyword, Symbol},

--- a/crates/smtlib/src/syntax/command.rs
+++ b/crates/smtlib/src/syntax/command.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use super::{
     s_expr::SExpr,
     sort::Sort,

--- a/crates/smtlib/src/syntax/fmt.rs
+++ b/crates/smtlib/src/syntax/fmt.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::syntax::{
     s_expr::{SExpr, SpecConstant},
     tokens::{ReservedWord, Symbol},

--- a/crates/smtlib/src/syntax/identifier.rs
+++ b/crates/smtlib/src/syntax/identifier.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use super::{
     s_expr::SExpr,
     tokens::{Numeral, ReservedWord, Symbol},

--- a/crates/smtlib/src/syntax/s_expr.rs
+++ b/crates/smtlib/src/syntax/s_expr.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use std::fmt::Display;
 
 use super::{

--- a/crates/smtlib/src/syntax/sort.rs
+++ b/crates/smtlib/src/syntax/sort.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use super::{identifier::Identifier, s_expr::SExpr};
 
 #[derive(Debug, Clone)]

--- a/crates/smtlib/src/syntax/term.rs
+++ b/crates/smtlib/src/syntax/term.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use super::{
     identifier::Identifier,
     s_expr::{SExpr, SpecConstant},

--- a/crates/smtlib/src/syntax/tokens.rs
+++ b/crates/smtlib/src/syntax/tokens.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use std::fmt::Display;
 
 use super::s_expr::SpecConstant;

--- a/crates/smtlib/src/theories.rs
+++ b/crates/smtlib/src/theories.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 macro_rules! def_fun_assoc {
     ($name:ident, $sym:expr) => {
         pub fn $name<T: Into<Term>, I: IntoIterator<Item = T>>(terms: I) -> Term {

--- a/crates/smtlib/src/theories/array_ex.rs
+++ b/crates/smtlib/src/theories/array_ex.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //!  https://smt-lib.org/theories-ArrayEx.shtml
 
 use crate::syntax::{

--- a/crates/smtlib/src/theories/core.rs
+++ b/crates/smtlib/src/theories/core.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //!  https://smt-lib.org/theories-Core.shtml
 
 use crate::syntax::{sort::Sort, term::Term, tokens::Symbol};

--- a/crates/smtlib/src/theories/ints.rs
+++ b/crates/smtlib/src/theories/ints.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! https://smt-lib.org/theories-Ints.shtml
 
 use crate::syntax::{sort::Sort, term::Term, tokens::Symbol};

--- a/src/expressions.rs
+++ b/src/expressions.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use std::ops::Deref as _;
 
 use crate::identifier::Identifier;

--- a/src/format/context.rs
+++ b/src/format/context.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 #[derive(Debug, Clone)]
 pub struct FormatContext<'a> {
     pub file_name: &'a str,

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::project;
 use std::io::Write;
 

--- a/src/gamehops/conjecture.rs
+++ b/src/gamehops/conjecture.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::parser::ast::GameInstanceName;
 
 #[derive(Debug, Clone)]

--- a/src/gamehops/equivalence/error.rs
+++ b/src/gamehops/equivalence/error.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::{
     gamehops::equivalence::Equivalence,
     util::prover_process::{ProverResponse, Result as ProverResponseResult},

--- a/src/gamehops/equivalence/mod.rs
+++ b/src/gamehops/equivalence/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::fmt::Write;
 use std::iter::FromIterator;

--- a/src/gamehops/equivalence/verify_fn.rs
+++ b/src/gamehops/equivalence/verify_fn.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use std::fmt::Write;
 use std::io::Write as _;

--- a/src/gamehops/mod.rs
+++ b/src/gamehops/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use std::fmt;
 
 use conjecture::Conjecture;

--- a/src/gamehops/reduction.rs
+++ b/src/gamehops/reduction.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use miette::Diagnostic;
 use thiserror::Error;
 

--- a/src/hacks.rs
+++ b/src/hacks.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use std::fmt::{Display, Result};
 
 use crate::writers::smt::exprs::SmtExpr;

--- a/src/identifier.rs
+++ b/src/identifier.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use game_ident::GameIdentifier;
 use pkg_ident::PackageConstIdentifier;
 use theorem_ident::TheoremIdentifier;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 #[macro_use]
 extern crate pest_derive;
 

--- a/src/package.rs
+++ b/src/package.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use miette::SourceSpan;
 
 use crate::identifier::Identifier;

--- a/src/packageinstance.rs
+++ b/src/packageinstance.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use itertools::Itertools as _;
 
 use crate::{

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use pest::{iterators::Pair, Span};
 
 #[derive(Clone, Debug)]

--- a/src/parser/common.rs
+++ b/src/parser/common.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::identifier::game_ident::{GameConstIdentifier, GameIdentifier};
 use crate::identifier::pkg_ident::{PackageConstIdentifier, PackageIdentifier};
 use crate::identifier::Identifier;

--- a/src/parser/composition.rs
+++ b/src/parser/composition.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use super::{
     common::*,
     error::{

--- a/src/parser/error.rs
+++ b/src/parser/error.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use std::fmt::{Debug, Display};
 
 use miette::{Diagnostic, SourceSpan};

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 #![allow(clippy::result_large_err)]
 
 pub mod common;

--- a/src/parser/package.rs
+++ b/src/parser/package.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use super::{
     common::*,
     error::{

--- a/src/parser/reduction.rs
+++ b/src/parser/reduction.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use std::collections::{HashMap, HashSet};
 
 use itertools::Itertools as _;

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 // These contain testdata
 pub(crate) mod games;
 pub(crate) mod packages;

--- a/src/parser/tests/complete/mod.rs
+++ b/src/parser/tests/complete/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use super::{
     games,
     packages::{self, *},

--- a/src/parser/tests/games.rs
+++ b/src/parser/tests/games.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use std::{collections::HashMap, iter::FromIterator as _};
 
 use crate::{

--- a/src/parser/tests/packages.rs
+++ b/src/parser/tests/packages.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use std::{collections::HashMap, iter::FromIterator as _};
 
 use crate::{

--- a/src/parser/tests/sound/games.rs
+++ b/src/parser/tests/sound/games.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::{
     parser::{
         composition::ParseGameError,

--- a/src/parser/tests/sound/mod.rs
+++ b/src/parser/tests/sound/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 mod games;
 mod packages;
 mod theorems;

--- a/src/parser/tests/sound/packages.rs
+++ b/src/parser/tests/sound/packages.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::{
     parser::{
         common::HandleTypeError,

--- a/src/parser/tests/sound/theorems.rs
+++ b/src/parser/tests/sound/theorems.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::parser::{
     error::{
         AssumptionExportsNotSufficientError, AssumptionMappingContainsDifferentPackagesError,

--- a/src/parser/tests/theorems.rs
+++ b/src/parser/tests/theorems.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use std::collections::HashMap;
 
 use crate::{

--- a/src/parser/theorem.rs
+++ b/src/parser/theorem.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use std::collections::HashMap;
 
 use crate::{

--- a/src/parser/wire_checks.rs
+++ b/src/parser/wire_checks.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use std::convert::TryInto as _;
 
 use itertools::Itertools;

--- a/src/project/error.rs
+++ b/src/project/error.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::parser;
 use miette::Diagnostic;
 use std::io::Error as IOError;

--- a/src/project/load.rs
+++ b/src/project/load.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use std::collections::HashMap;
 
 use super::*;

--- a/src/project/mod.rs
+++ b/src/project/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 /**
  *  project is the high-level structure of sspverif.
  *

--- a/src/project/resolve.rs
+++ b/src/project/resolve.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 /*
 use super::{
     assumption::ResolvedAssumption,

--- a/src/proof.rs
+++ b/src/proof.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use std::collections::{HashMap, HashSet, VecDeque};
 
 use crate::{expressions::Expression, gamehops::GameHop, theorem::GameInstance};

--- a/src/split.rs
+++ b/src/split.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use miette::SourceSpan;
 
 use crate::{

--- a/src/statement.rs
+++ b/src/statement.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use miette::SourceSpan;
 use pest::Span;
 

--- a/src/testdata/keypkg.rs
+++ b/src/testdata/keypkg.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::expressions::Expression;
 use crate::identifier::Identifier;
 use crate::package::{OracleDef, OracleSig, Package, PackageInstance};

--- a/src/testdata/mod.rs
+++ b/src/testdata/mod.rs
@@ -1,2 +1,4 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 // pub mod keypkg;
 // pub mod modprf;

--- a/src/testdata/modprf.rs
+++ b/src/testdata/modprf.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::expressions::Expression;
 use crate::identifier::Identifier;
 use crate::package::{OracleDef, OracleSig, Package, PackageInstance};

--- a/src/theorem.rs
+++ b/src/theorem.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::{
     expressions::Expression,
     gamehops::{reduction::Assumption, GameHop},

--- a/src/transforms/mod.rs
+++ b/src/transforms/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::{package::Composition, theorem::Theorem};
 
 // commented out because we currently don't handle parametric types :(

--- a/src/transforms/resolveoracles.rs
+++ b/src/transforms/resolveoracles.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::package::{Composition, Edge, OracleDef, Package, PackageInstance};
 use crate::statement::{CodeBlock, IfThenElse, InvokeOracleStatement, Statement};
 

--- a/src/transforms/returnify.rs
+++ b/src/transforms/returnify.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use miette::SourceSpan;
 
 use crate::package::Composition;

--- a/src/transforms/samplify.rs
+++ b/src/transforms/samplify.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::expressions::Expression;
 use crate::package::Composition;
 use crate::statement::{CodeBlock, IfThenElse, Statement};

--- a/src/transforms/split_partial.rs
+++ b/src/transforms/split_partial.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use std::collections::HashMap;
 use std::convert::Infallible;
 

--- a/src/transforms/tableinitialize.rs
+++ b/src/transforms/tableinitialize.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use std::convert::Infallible;
 
 use crate::expressions::Expression;

--- a/src/transforms/theorem_transforms.rs
+++ b/src/transforms/theorem_transforms.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use std::{collections::HashSet, convert::Infallible};
 
 use crate::{theorem::GameInstance, types::Type};

--- a/src/transforms/treeify.rs
+++ b/src/transforms/treeify.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use std::convert::Infallible;
 
 use crate::package::Composition;

--- a/src/transforms/type_extract.rs
+++ b/src/transforms/type_extract.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use std::collections::HashSet;
 use std::convert::Infallible;
 

--- a/src/transforms/unwrapify.rs
+++ b/src/transforms/unwrapify.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use std::convert::Infallible;
 
 use miette::SourceSpan;

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::identifier::{pkg_ident::PackageIdentifier, Identifier};
 
 #[allow(dead_code)]

--- a/src/ui/indicatif.rs
+++ b/src/ui/indicatif.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use indicatif::{MultiProgress, ProgressBar};
 use indicatif_log_bridge::LogWrapper;
 use itertools::Itertools;

--- a/src/ui/mock.rs
+++ b/src/ui/mock.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::ui::TheoremUI;
 use mockall::mock;
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 pub(crate) mod indicatif;
 #[cfg(test)]
 pub(crate) mod mock;

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 pub mod process;
 pub mod prover_process;
 pub mod scope;

--- a/src/util/process.rs
+++ b/src/util/process.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //use crate::project::error::Result;
 use thiserror::Error;
 

--- a/src/util/prover_process.rs
+++ b/src/util/prover_process.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use std::fmt;
 use std::fmt::Write;
 use std::result;

--- a/src/util/scope.rs
+++ b/src/util/scope.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use thiserror::Error;
 
 use crate::identifier::Identifier;

--- a/src/util/smtmodel.rs
+++ b/src/util/smtmodel.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::debug_assert_matches;
 
 use pest::Parser;

--- a/src/writers/mod.rs
+++ b/src/writers/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 pub mod pseudocode;
 pub mod smt;
 pub mod tex;

--- a/src/writers/pseudocode/fmtwriter.rs
+++ b/src/writers/pseudocode/fmtwriter.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use std::fmt::Write;
 
 use crate::expressions::Expression;

--- a/src/writers/pseudocode/mod.rs
+++ b/src/writers/pseudocode/mod.rs
@@ -1,2 +1,4 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 pub mod fmtwriter;
 pub mod writer;

--- a/src/writers/pseudocode/writer.rs
+++ b/src/writers/pseudocode/writer.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use std::io::Write;
 
 use crate::expressions::Expression;

--- a/src/writers/smt/contexts/equivalence.rs
+++ b/src/writers/smt/contexts/equivalence.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::{
     gamehops::equivalence::EquivalenceContext,
     writers::smt::{

--- a/src/writers/smt/contexts/game_inst.rs
+++ b/src/writers/smt/contexts/game_inst.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::{
     expressions::Expression,
     identifier::game_ident::GameConstIdentifier,

--- a/src/writers/smt/contexts/mod.rs
+++ b/src/writers/smt/contexts/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::{
     transforms::samplify::SampleInfo,
     types::Type,

--- a/src/writers/smt/contexts/oracle.rs
+++ b/src/writers/smt/contexts/oracle.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::package::{OracleDef, OracleSig};
 use crate::transforms::samplify::SampleInfo;
 use crate::types::Type;

--- a/src/writers/smt/contexts/pkg_inst.rs
+++ b/src/writers/smt/contexts/pkg_inst.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::expressions::Expression;
 use crate::identifier::pkg_ident::{
     PackageConstIdentifier, PackageIdentifier, PackageStateIdentifier,

--- a/src/writers/smt/contexts/split_oracle.rs
+++ b/src/writers/smt/contexts/split_oracle.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::{
     split::{SplitOracleDef, SplitPath},
     types::Type,

--- a/src/writers/smt/declare.rs
+++ b/src/writers/smt/declare.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use super::{
     exprs::{SmtExpr, SmtWrap},
     sorts::Sort,

--- a/src/writers/smt/expr_expr.rs
+++ b/src/writers/smt/expr_expr.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use super::exprs::SmtExpr;
 use crate::expressions::Expression;
 use crate::types::Type;

--- a/src/writers/smt/expr_term.rs
+++ b/src/writers/smt/expr_term.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::{
     expressions::Expression,
     identifier::{

--- a/src/writers/smt/exprs.rs
+++ b/src/writers/smt/exprs.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use std::fmt::Display;
 
 use sspverif_smtlib::syntax::s_expr::SExpr;

--- a/src/writers/smt/identifier.rs
+++ b/src/writers/smt/identifier.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use sspverif_smtlib::syntax::term::Term;
 
 use crate::identifier::Identifier;

--- a/src/writers/smt/mod.rs
+++ b/src/writers/smt/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 pub mod exprs;
 pub mod writer;
 

--- a/src/writers/smt/names.rs
+++ b/src/writers/smt/names.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::transforms::samplify::Position as SamplePosition;
 use std::{fmt::Write, marker::PhantomData};
 

--- a/src/writers/smt/partials.rs
+++ b/src/writers/smt/partials.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use std::collections::HashMap;
 
 use crate::split::{SplitPath, SplitType};

--- a/src/writers/smt/patterns/datastructures/game_consts.rs
+++ b/src/writers/smt/patterns/datastructures/game_consts.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::{
     package::Composition,
     theorem::Theorem,

--- a/src/writers/smt/patterns/datastructures/game_state.rs
+++ b/src/writers/smt/patterns/datastructures/game_state.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::{
     expressions::Expression,
     identifier::game_ident::GameConstIdentifier,

--- a/src/writers/smt/patterns/datastructures/intermediate_state.rs
+++ b/src/writers/smt/patterns/datastructures/intermediate_state.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::{
     expressions::Expression,
     identifier::pkg_ident::PackageConstIdentifier,

--- a/src/writers/smt/patterns/datastructures/mod.rs
+++ b/src/writers/smt/patterns/datastructures/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 pub mod game_consts;
 pub mod game_state;
 //mod intermediate_state;

--- a/src/writers/smt/patterns/datastructures/normal_return.rs
+++ b/src/writers/smt/patterns/datastructures/normal_return.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use super::{DatastructurePattern, DatastructureSpec};
 use crate::expressions::Expression;
 use crate::identifier::game_ident::GameConstIdentifier;

--- a/src/writers/smt/patterns/datastructures/partial_return.rs
+++ b/src/writers/smt/patterns/datastructures/partial_return.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use super::{DatastructurePattern, DatastructureSpec};
 use crate::expressions::Expression;
 use crate::identifier::game_ident::GameConstIdentifier;

--- a/src/writers/smt/patterns/datastructures/pkg_consts.rs
+++ b/src/writers/smt/patterns/datastructures/pkg_consts.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::{
     package::Package,
     types::Type,

--- a/src/writers/smt/patterns/datastructures/pkg_state.rs
+++ b/src/writers/smt/patterns/datastructures/pkg_state.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::{
     expressions::Expression,
     identifier::pkg_ident::PackageConstIdentifier,

--- a/src/writers/smt/patterns/datastructures/return_value.rs
+++ b/src/writers/smt/patterns/datastructures/return_value.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::{
     types::Type,
     writers::smt::{

--- a/src/writers/smt/patterns/datastructures/theorem_consts.rs
+++ b/src/writers/smt/patterns/datastructures/theorem_consts.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::{
     theorem::Theorem,
     types::Type,

--- a/src/writers/smt/patterns/functions.rs
+++ b/src/writers/smt/patterns/functions.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 pub mod const_mapping;
 //pub mod dispatch_oracle;
 pub mod oracle;

--- a/src/writers/smt/patterns/functions/const_mapping.rs
+++ b/src/writers/smt/patterns/functions/const_mapping.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::{
     package::{Composition, Package},
     theorem::Theorem,

--- a/src/writers/smt/patterns/functions/dispatch_oracle.rs
+++ b/src/writers/smt/patterns/functions/dispatch_oracle.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::{
     expressions::Expression,
     identifier::{game_ident::GameConstIdentifier, pkg_ident::PackageConstIdentifier},

--- a/src/writers/smt/patterns/functions/oracle.rs
+++ b/src/writers/smt/patterns/functions/oracle.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::{
     expressions::Expression,
     identifier::{game_ident::GameConstIdentifier, pkg_ident::PackageConstIdentifier},

--- a/src/writers/smt/patterns/functions/partial_oracle.rs
+++ b/src/writers/smt/patterns/functions/partial_oracle.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::{
     expressions::Expression,
     identifier::{game_ident::GameConstIdentifier, pkg_ident::PackageConstIdentifier},

--- a/src/writers/smt/patterns/functions/relation.rs
+++ b/src/writers/smt/patterns/functions/relation.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::{
     types::Type,
     writers::smt::{

--- a/src/writers/smt/patterns/instance_names.rs
+++ b/src/writers/smt/patterns/instance_names.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use std::borrow::Borrow;
 
 use crate::{expressions::Expression, types::Type, writers::smt::exprs::SmtExpr};

--- a/src/writers/smt/patterns/mod.rs
+++ b/src/writers/smt/patterns/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 pub(crate) mod datastructures;
 pub(crate) mod functions;
 pub mod instance_names;

--- a/src/writers/smt/patterns/oracle_args.rs
+++ b/src/writers/smt/patterns/oracle_args.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use std::fmt::Display;
 
 use crate::writers::smt::declare;

--- a/src/writers/smt/patterns/oracle_args/game_consts.rs
+++ b/src/writers/smt/patterns/oracle_args/game_consts.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::writers::smt::patterns::{
     game_consts::GameConstsPattern as GameConstsDatatypePattern, DatastructurePattern as _,
 };

--- a/src/writers/smt/patterns/oracle_args/game_state.rs
+++ b/src/writers/smt/patterns/oracle_args/game_state.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::{
     expressions::Expression,
     identifier::game_ident::GameConstIdentifier,

--- a/src/writers/smt/patterns/oracle_args/theorem_consts.rs
+++ b/src/writers/smt/patterns/oracle_args/theorem_consts.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::writers::smt::patterns::{
     theorem_consts::TheoremConstsPattern as TheoremConstsDatatypePattern, DatastructurePattern as _,
 };

--- a/src/writers/smt/patterns/relations/equal_aborts.rs
+++ b/src/writers/smt/patterns/relations/equal_aborts.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::writers::smt::{
     exprs::{SmtEq2, SmtExpr, SmtIs, SmtLet},
     patterns::{

--- a/src/writers/smt/patterns/relations/mod.rs
+++ b/src/writers/smt/patterns/relations/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 pub mod equal_aborts;
 pub mod no_abort;
 pub mod same_output;

--- a/src/writers/smt/patterns/relations/no_abort.rs
+++ b/src/writers/smt/patterns/relations/no_abort.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::writers::smt::{
     exprs::{SmtAnd, SmtExpr, SmtIs, SmtNot},
     patterns::{

--- a/src/writers/smt/patterns/relations/same_output.rs
+++ b/src/writers/smt/patterns/relations/same_output.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::writers::smt::{
     exprs::{SmtEq2, SmtExpr},
     patterns::{relation::Relation, DatastructurePattern, FunctionPattern, ReturnSelector},

--- a/src/writers/smt/patterns/theorem_constants.rs
+++ b/src/writers/smt/patterns/theorem_constants.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::writers::smt::{declare, exprs::SmtExpr, sorts::Sort};
 
 pub(crate) mod constants;

--- a/src/writers/smt/patterns/theorem_constants/constants.rs
+++ b/src/writers/smt/patterns/theorem_constants/constants.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use sspverif_smtlib::{
     syntax::{command::Command, term::Term},
     theories,

--- a/src/writers/smt/patterns/theorem_constants/oracle_args.rs
+++ b/src/writers/smt/patterns/theorem_constants/oracle_args.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::{
     types::Type,
     writers::smt::{patterns::theorem_constants::ConstantPattern, sorts::Sort},

--- a/src/writers/smt/patterns/theorem_constants/return_is_abort.rs
+++ b/src/writers/smt/patterns/theorem_constants/return_is_abort.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::{
     types::Type,
     writers::smt::{

--- a/src/writers/smt/patterns/theorem_constants/return_normal.rs
+++ b/src/writers/smt/patterns/theorem_constants/return_normal.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::{
     expressions::Expression,
     identifier::{game_ident::GameConstIdentifier, pkg_ident::PackageConstIdentifier},

--- a/src/writers/smt/patterns/theorem_constants/return_partial.rs
+++ b/src/writers/smt/patterns/theorem_constants/return_partial.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::{
     expressions::Expression,
     identifier::{game_ident::GameConstIdentifier, pkg_ident::PackageConstIdentifier},

--- a/src/writers/smt/patterns/theorem_constants/return_value.rs
+++ b/src/writers/smt/patterns/theorem_constants/return_value.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::{
     types::Type,
     writers::smt::{patterns::theorem_constants::ConstantPattern, sorts::Sort},

--- a/src/writers/smt/patterns/theorem_constants/state_intermediate.rs
+++ b/src/writers/smt/patterns/theorem_constants/state_intermediate.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::{
     expressions::Expression,
     identifier::pkg_ident::PackageConstIdentifier,

--- a/src/writers/smt/patterns/variables.rs
+++ b/src/writers/smt/patterns/variables.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 /*
  *
  * old:

--- a/src/writers/smt/sorts.rs
+++ b/src/writers/smt/sorts.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::types::Type;
 
 use super::exprs::SmtExpr;

--- a/src/writers/smt/tests/mod.rs
+++ b/src/writers/smt/tests/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use super::patterns::{game_consts, pkg_consts, pkg_state, DatastructurePattern};
 use crate::{
     parser::tests::*,

--- a/src/writers/smt/writer.rs
+++ b/src/writers/smt/writer.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use std::collections::HashSet;
 
 use crate::expressions::Expression;

--- a/src/writers/tex/mod.rs
+++ b/src/writers/tex/mod.rs
@@ -1,1 +1,3 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 pub mod writer;

--- a/src/writers/tex/writer.rs
+++ b/src/writers/tex/writer.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use std::collections::HashSet;
 use std::fs::File;
 use std::io::Write;


### PR DESCRIPTION
Add LICENSE.txt and SPDX headers. Thanks ed!

Let's get agreement from all who have contributed Rust code. Approving the PR is interpreted as agreeing to licensing the code under Apache-2.0.

For now this probably only licenses the Rust code, not the SSBee example code. At least that doesn't have SPDX headers. Not even sure that counts as source code. Open to discuss this.

Closes #124.