### PR TITLE
Extract all the relevant types

### DIFF
--- a/example-projects/ae/games/mod-prf-real.comp.ssp
+++ b/example-projects/ae/games/mod-prf-real.comp.ssp
@@ -1,20 +1,20 @@
 composition Modprfreal {
     const n: Integer;
     const prf: fn Bits(n), Bits(n) -> Bits(n);
-    
+
+    instance key = KeyReal {
+        params {
+            n: n,
+        }
+    }
+
     instance mod_prf = modPRF {
         params {
             n:   n,
           prf: prf,
         }
     }
-    
-    instance key = KeyReal {
-        params {
-            n: n,
-        }
-    }
-        
+
     compose {
         adversary: {
             Eval: mod_prf,

--- a/example-projects/ae/proofs/invariant-PRF.smt2
+++ b/example-projects/ae/proofs/invariant-PRF.smt2
@@ -10,20 +10,21 @@
 ;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define-fun randomness-mapping-EVAL (        
+(define-fun randomness-mapping-Eval (
         (ltk-mod     Bits_n)
-        (ltk-mon     Bits_n)
+        (ltk-mon     Bits_n))
+        Bool
         true
-))
+)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;
 ; Invariant --- note that the invariant needs to be game-global 
-;               Having different variants for EVAL & GET allows to prove wrong things.
+;               Having different variants for Eval & Get allows to prove wrong things.
 ;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define-fun invariant-EVAL      (
+(define-fun invariant-Eval      (
         (state-mod  CompositionState-modprfreal )
         (state-mon  CompositionState-monprfreal)
 )

--- a/example-projects/ae/proofs/modularize.ssp
+++ b/example-projects/ae/proofs/modularize.ssp
@@ -36,28 +36,28 @@ proof Modularize {
     gamehops {
     equivalence modprfreal monprfreal 
         {
-            EVAL: 
+            Eval: 
             {
                 invariant: [
                     ./proofs/invariant-PRF.smt2
                 ]
 
                 lemmas {
-                    aborts-equal-EVAL:   []
-                    invariant-EVAL:      [no-abort-EVAL]
-                    same-output-EVAL:    [no-abort-EVAL]
+                    aborts-equal-Eval:   []
+                    invariant-Eval:      [no-abort-Eval]
+                    same-output-Eval:    [no-abort-Eval]
                 }
             }
-            GET: 
+            Get: 
             {
                 invariant: [
                     ./proofs/invariant-PRF.smt2
                 ]
 
                 lemmas {
-                    aborts-equal-GET:   []
-                    invariant-GET:      [no-abort-GET]
-                    same-output-GET:    [no-abort-GET]
+                    aborts-equal-Get:   []
+                    invariant-Get:      [no-abort-Get]
+                    same-output-Get:    [no-abort-Get]
                 }
             }
         }

--- a/src/gamehops/equivalence/verify_fn.rs
+++ b/src/gamehops/equivalence/verify_fn.rs
@@ -48,15 +48,35 @@ fn verify_oracle<UI: ProofUI>(
     };
     std::thread::sleep(std::time::Duration::from_millis(20));
 
+    log::debug!(
+        "emitting base declarations for {}-{}",
+        eq.left_name,
+        eq.right_name
+    );
     prover.write_smt(SmtExpr::Comment("\n".to_string()))?;
     prover.write_smt(SmtExpr::Comment("base declarations:\n".to_string()))?;
     eqctx.emit_base_declarations(&mut prover)?;
+    log::debug!(
+        "emitting proof paramfuncs for {}-{}",
+        eq.left_name,
+        eq.right_name
+    );
     prover.write_smt(SmtExpr::Comment("\n".to_string()))?;
     prover.write_smt(SmtExpr::Comment("proof param funcs:\n".to_string()))?;
     eqctx.emit_proof_paramfuncs(&mut prover)?;
+    log::debug!(
+        "emitting game definitions for {}-{}",
+        eq.left_name,
+        eq.right_name
+    );
     prover.write_smt(SmtExpr::Comment("\n".to_string()))?;
     prover.write_smt(SmtExpr::Comment("game definitions:\n".to_string()))?;
     eqctx.emit_game_definitions(&mut prover)?;
+    log::debug!(
+        "emitting const declarations for {}-{}",
+        eq.left_name,
+        eq.right_name
+    );
     eqctx.emit_constant_declarations(&mut prover)?;
 
     for oracle_sig in req_oracles {

--- a/src/packageinstance.rs
+++ b/src/packageinstance.rs
@@ -129,10 +129,11 @@ impl PackageInstance {
                 &types,
             );
 
-        let new_oracles = pkg
-            .oracles
+        let new_params = pkg
+            .params
             .iter()
-            .map(|oracle_def| inst_ctx.rewrite_oracle_def(oracle_def.clone()))
+            .cloned()
+            .map(|(name, ty, span)| (name, inst_ctx.rewrite_type(ty), span))
             .collect();
 
         let new_state = pkg
@@ -142,24 +143,24 @@ impl PackageInstance {
             .map(|(name, ty, span)| (name, inst_ctx.rewrite_type(ty), span))
             .collect();
 
-        let new_params = pkg
-            .params
+        let new_imports = pkg
+            .imports
             .iter()
             .cloned()
-            .map(|(name, ty, span)| (name, inst_ctx.rewrite_type(ty), span))
+            .map(|(sig, span)| (inst_ctx.rewrite_oracle_sig(sig), span))
             .collect();
 
-        // let new_split_oracles = pkg
-        //     .split_oracles
-        //     .iter()
-        //     .map(|split_oracle_def| inst_ctx.rewrite_split_oracle_def(split_oracle_def.clone()))
-        //     .collect();
+        let new_oracles = pkg
+            .oracles
+            .iter()
+            .map(|oracle_def| inst_ctx.rewrite_oracle_def(oracle_def.clone()))
+            .collect();
 
         let pkg = Package {
             oracles: new_oracles,
             state: new_state,
             params: new_params,
-            //split_oracles: new_split_oracles,
+            imports: new_imports,
             ..pkg.clone()
         };
 

--- a/src/transforms/type_extract.rs
+++ b/src/transforms/type_extract.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 use std::convert::Infallible;
 
-use crate::package::Composition;
+use crate::package::{Composition, Edge, Export};
 use crate::statement::{CodeBlock, InvokeOracleStatement, Statement};
 use crate::types::Type;
 
@@ -14,17 +14,57 @@ impl super::Transformation for Transformation<'_> {
     fn transform(&self) -> Result<(Composition, HashSet<Type>), Infallible> {
         let mut set = HashSet::new();
 
-        // TODO: https://github.com/sspverif/sspverif/issues/118: extract types of game state, params, oracle args, oracle return
+        // extract game const types
+        set.extend(self.0.consts.iter().map(|(_, ty)| ty).cloned());
+
+        // extract oracle arg an return types from edges
+        set.extend(self.0.edges.iter().flat_map(|Edge(_, _, sig)| {
+            sig.args
+                .iter()
+                .map(|(_, ty)| ty)
+                .chain(Some(&sig.tipe))
+                .cloned()
+        }));
+
+        // extract oracle arg an return types from exports
+        set.extend(self.0.exports.iter().flat_map(|Export(_, sig)| {
+            sig.args
+                .iter()
+                .map(|(_, ty)| ty)
+                .chain(Some(&sig.tipe))
+                .cloned()
+        }));
+
+        // extract types from package params, state, imported oracle signatures and defined oracle
+        // seignatures.
+        set.extend(self.0.pkgs.iter().flat_map(|pkg_inst| {
+            let pkg = &pkg_inst.pkg;
+
+            // first prepare iterators for all the relevant types that are extracted
+            let params = pkg.params.iter().map(|(_, ty, _)| ty);
+            let state = pkg.state.iter().map(|(_, ty, _)| ty);
+            let oracle_imports = pkg
+                .imports
+                .iter()
+                .flat_map(|(sig, _)| sig.args.iter().map(|(_, ty)| ty).chain(Some(&sig.tipe)));
+            let oracle_definitions = pkg.oracles.iter().flat_map(|oracle_def| {
+                let sig = &oracle_def.sig;
+                sig.args.iter().map(|(_, ty)| ty).chain(Some(&sig.tipe))
+            });
+
+            // Then chain them and clone the items, because the set wants owned types
+            params
+                .chain(state)
+                .chain(oracle_imports)
+                .chain(oracle_definitions)
+                .cloned()
+        }));
 
         let insts = &self.0.pkgs.iter();
         let oracles = insts.clone().flat_map(|inst| inst.pkg.oracles.clone());
 
-        // TODO: https://github.com/sspverif/sspverif/issues/118: extract types of package state, params, oracle args, oracle return
-
-        let codeblocks = oracles.map(|odef| odef.code);
-
-        for cb in codeblocks {
-            extract_types_from_codeblock(&mut set, cb);
+        for oracle in oracles {
+            extract_types_from_codeblock(&mut set, oracle.code);
         }
 
         Ok((self.0.clone(), set))


### PR DESCRIPTION
We didn't extract all the relevant types from the code. We now should. This makes the ae example fail with a new error. Before it was complaining about missing types

Closes #118 