### PR TITLE
Fix: oracle code when same *package* has multiple *instances* in a single *game*

### DIFF
--- a/src/writers/smt/contexts/oracle.rs
+++ b/src/writers/smt/contexts/oracle.rs
@@ -44,6 +44,7 @@ impl<'a> OracleContext<'a> {
         let game_name: &'a _ = gctx.game_name();
         let game_inst_name: &'a _ = gctx.game_inst_name();
         let pkg_name: &'a _ = pctx.pkg_name();
+        let pkg_inst_name: &'a _ = pctx.pkg_inst_name();
         let oracle_name: &'a _ = self.oracle_name();
         let oracle_args: &'a _ = self.oracle_args();
         let game_params: &'a _ = gctx.game_params();
@@ -53,6 +54,7 @@ impl<'a> OracleContext<'a> {
             game_name,
             game_inst_name,
             pkg_name,
+            pkg_inst_name,
             oracle_name,
             oracle_args,
             game_params,

--- a/src/writers/smt/patterns/functions/oracle.rs
+++ b/src/writers/smt/patterns/functions/oracle.rs
@@ -21,6 +21,7 @@ pub struct OraclePattern<'a> {
     pub game_name: &'a str,
     pub game_inst_name: &'a str,
     pub pkg_name: &'a str,
+    pub pkg_inst_name: &'a str,
     pub oracle_name: &'a str,
     pub oracle_args: &'a [(String, Type)],
     pub game_params: &'a [(GameConstIdentifier, Expression)],
@@ -36,6 +37,7 @@ impl FunctionPattern for OraclePattern<'_> {
             .push(self.game_name)
             .push(self.game_inst_name)
             .push(self.pkg_name)
+            .push(self.pkg_inst_name)
             .maybe_extend(&pkg_encoded_params)
             .push(self.oracle_name)
             .build()


### PR DESCRIPTION
Note that we still need the pkg_name in the oracle pattern because it is needed to generate the sort for the return value!