### PR TITLE
Verify Completeness of Induction Step

### DIFF
--- a/example-projects/4WHS/theorem/Full4WHS.ssp
+++ b/example-projects/4WHS/theorem/Full4WHS.ssp
@@ -1400,6 +1400,7 @@ theorem Full4WHS {
                     invariant:    [no-abort, lemma-randomness]
                     same-output:  [no-abort, lemma-randomness]
                     equal-aborts: [lemma-randomness]
+                    lemma-randomness: admit []
                 }
             }
              Send3: {

--- a/example-projects/hello-world-oracle-rename/theorem/proof.ssp
+++ b/example-projects/hello-world-oracle-rename/theorem/proof.ssp
@@ -51,6 +51,7 @@ theorem Proof {
                     equal-aborts: [trivial]
                     invariant:    [no-abort]
                     same-output:  [no-abort]
+                    trivial: []
                 }
             }
         }

--- a/example-projects/kem-dem-cca-security/theorem/proof.ssp
+++ b/example-projects/kem-dem-cca-security/theorem/proof.ssp
@@ -212,6 +212,7 @@ theorem Proof {
                     invariant: [no-abort, lemma-rand-is-eq]
                     same-output: [no-abort, lemma-rand-is-eq]
                     equal-aborts: []
+                    lemma-rand-is-eq: admit []
                 }
             }
 
@@ -224,6 +225,7 @@ theorem Proof {
                     invariant: [no-abort]
                     same-output: [no-abort, lemma-kem-correctness]
                     equal-aborts: []
+                    lemma-kem-correctness: admit []
                 }
             }
         }
@@ -304,6 +306,7 @@ theorem Proof {
                     invariant: [no-abort, lemma-rand-is-eq]
                     same-output: [no-abort, lemma-rand-is-eq]
                     equal-aborts: []
+                    lemma-rand-is-eq: admit []
                 }
             }
 
@@ -316,6 +319,7 @@ theorem Proof {
                     invariant: [no-abort]
                     same-output: [no-abort, lemma-kem-correctness]
                     equal-aborts: []
+                    lemma-kem-correctness: admit []
                 }
             }
         }
@@ -346,6 +350,7 @@ theorem Proof {
                     invariant: [no-abort, lemma-rand-is-eq]
                     same-output: [no-abort, lemma-rand-is-eq]
                     equal-aborts: []
+                    lemma-rand-is-eq: admit []
                 }
             }
 
@@ -358,6 +363,7 @@ theorem Proof {
                     invariant: [no-abort]
                     same-output: [no-abort, lemma-kem-correctness]
                     equal-aborts: []
+                    lemma-kem-correctness: admit []
                 }
             }
         }

--- a/src/gamehops/equivalence/verify_fn.rs
+++ b/src/gamehops/equivalence/verify_fn.rs
@@ -104,28 +104,30 @@ fn verify_oracle<UI: TheoremUI>(
                 claim.name(),
             );
 
-            writeln!(prover, "(push 1)").unwrap();
-            eqctx.emit_claim_assert(&mut prover, export.name(), &claim)?;
-            match prover.check_sat()? {
-                ProverResponse::Unsat => {}
-                response => {
-                    let modelfile = prover.get_model().map(|(modelstring, _model)| {
-                        let mut modelfile =
-                            tempfile::Builder::new().suffix(".smt2").tempfile().unwrap();
-                        modelfile.write_all(modelstring.as_bytes()).unwrap();
-                        let (_, fname) = modelfile.keep().unwrap();
-                        fname
-                    });
-                    prover.close();
-                    return Err(Error::ClaimTheoremFailed {
-                        claim_name: claim.name().to_string(),
-                        oracle_name: export.name().to_string(),
-                        response,
-                        modelfile,
-                    });
+            if !claim.is_admited() {
+                writeln!(prover, "(push 1)").unwrap();
+                eqctx.emit_claim_assert(&mut prover, export.name(), &claim)?;
+                match prover.check_sat()? {
+                    ProverResponse::Unsat => {}
+                    response => {
+                        let modelfile = prover.get_model().map(|(modelstring, _model)| {
+                            let mut modelfile =
+                                tempfile::Builder::new().suffix(".smt2").tempfile().unwrap();
+                            modelfile.write_all(modelstring.as_bytes()).unwrap();
+                            let (_, fname) = modelfile.keep().unwrap();
+                            fname
+                        });
+                        prover.close();
+                        return Err(Error::ClaimTheoremFailed {
+                            claim_name: claim.name().to_string(),
+                            oracle_name: export.name().to_string(),
+                            response,
+                            modelfile,
+                        });
+                    }
                 }
+                writeln!(prover, "(pop 1)").unwrap();
             }
-            writeln!(prover, "(pop 1)").unwrap();
             ui.lock().unwrap().finish_lemma(
                 &eqctx.theorem().name,
                 &proofstep_name,

--- a/src/gamehops/equivalence/verify_fn.rs
+++ b/src/gamehops/equivalence/verify_fn.rs
@@ -104,7 +104,7 @@ fn verify_oracle<UI: TheoremUI>(
                 claim.name(),
             );
 
-            if !claim.is_admited() {
+            if !claim.is_admitted() {
                 writeln!(prover, "(push 1)").unwrap();
                 eqctx.emit_claim_assert(&mut prover, export.name(), &claim)?;
                 match prover.check_sat()? {

--- a/src/parser/error.rs
+++ b/src/parser/error.rs
@@ -14,6 +14,20 @@ use super::ast::Identifier as _;
 pub enum NewError {}
 
 #[derive(Error, Diagnostic, Debug)]
+#[error("claim {claim}, oracle {oracle} is admited")]
+#[diagnostic(code(domino::code::theorem::inductionstep::admited), severity(Warning))]
+pub struct AdmitedClaimWarning {
+    #[source_code]
+    pub source_code: miette::NamedSource<String>,
+
+    #[label("this claim block")]
+    pub at: SourceSpan,
+
+    pub claim: String,
+    pub oracle: String,
+}
+
+#[derive(Error, Diagnostic, Debug)]
 #[error("could not prove claim {target}. provable claims: {provable}")]
 #[diagnostic(code(domino::code::theorem::inductionstep::unprovable))]
 pub struct InductionStepUnprovableError {

--- a/src/parser/error.rs
+++ b/src/parser/error.rs
@@ -14,9 +14,9 @@ use super::ast::Identifier as _;
 pub enum NewError {}
 
 #[derive(Error, Diagnostic, Debug)]
-#[error("claim {claim}, oracle {oracle} is admited")]
-#[diagnostic(code(domino::code::theorem::inductionstep::admited), severity(Warning))]
-pub struct AdmitedClaimWarning {
+#[error("claim {claim}, oracle {oracle} is admitted")]
+#[diagnostic(code(domino::code::theorem::inductionstep::admitted), severity(Warning))]
+pub struct AdmittedClaimWarning {
     #[source_code]
     pub source_code: miette::NamedSource<String>,
 

--- a/src/parser/error.rs
+++ b/src/parser/error.rs
@@ -14,6 +14,20 @@ use super::ast::Identifier as _;
 pub enum NewError {}
 
 #[derive(Error, Diagnostic, Debug)]
+#[error("could not prove claim {target}. provable claims: {provable}")]
+#[diagnostic(code(domino::code::theorem::inductionstep::unprovable))]
+pub struct InductionStepUnprovableError {
+    #[source_code]
+    pub source_code: miette::NamedSource<String>,
+
+    #[label("this claim block")]
+    pub at: SourceSpan,
+
+    pub target: String,
+    pub provable: String,
+}
+
+#[derive(Error, Diagnostic, Debug)]
 #[error("undefined randomness sort '{randomness_sort}', supported: custom, none, simple")]
 #[diagnostic(code(domino::code::theorem::unknown_randomness_sort))]
 pub struct UndefinedRandomnessSortError {

--- a/src/parser/error.rs
+++ b/src/parser/error.rs
@@ -15,7 +15,10 @@ pub enum NewError {}
 
 #[derive(Error, Diagnostic, Debug)]
 #[error("claim {claim}, oracle {oracle} is admitted")]
-#[diagnostic(code(domino::code::theorem::inductionstep::admitted), severity(Warning))]
+#[diagnostic(
+    code(domino::code::theorem::inductionstep::admitted),
+    severity(Warning)
+)]
 pub struct AdmittedClaimWarning {
     #[source_code]
     pub source_code: miette::NamedSource<String>,

--- a/src/parser/ssp.pest
+++ b/src/parser/ssp.pest
@@ -303,7 +303,8 @@ theorem_spec_list = { ( const_decl | instance_decl | hybrid_instance_decl | assu
         lemmas_spec = {kw_lemmas ~ "{" ~ (lemma_line)* ~ "}"}
 
           /// A single lemma with its dependencies.
-          lemma_line = {smt_identifier ~ ":" ~ "[" ~ ( smt_identifier  ~ ","?)* ~ "]"}
+          lemma_line = {smt_identifier ~ ":" ~ lemma_modifier? ~ "[" ~ ( smt_identifier  ~ ","?)* ~ "]"}
+          lemma_modifier = { identifier }
 
     /// A hybrid argument combining both reduction and equivalence steps.
     hybrid = { kw_hybrid ~ identifier ~ "{" ~ hybrid_reduction ~ hybrid_equivalence ~ "}" }

--- a/src/parser/tests/complete/mod.rs
+++ b/src/parser/tests/complete/mod.rs
@@ -159,25 +159,25 @@ fn equivalence_parses() {
                     name: "invariant".into(),
                     ty: ClaimType::Invariant,
                     dependencies: vec![],
-                    admited: false,
+                    admitted: false,
                 },
                 Claim {
                     name: "equal-aborts".into(),
                     ty: ClaimType::Lemma,
                     dependencies: vec![],
-                    admited: false
+                    admitted: false
                 },
                 Claim {
                     name: "same-output".into(),
                     ty: ClaimType::Lemma,
                     dependencies: vec![],
-                    admited: false
+                    admitted: false
                 },
                 Claim {
                     name: "smt_ident".into(),
                     ty: ClaimType::Lemma,
                     dependencies: vec![],
-                    admited: false
+                    admitted: false
                 },
             ]
         )]

--- a/src/parser/tests/complete/mod.rs
+++ b/src/parser/tests/complete/mod.rs
@@ -154,11 +154,28 @@ fn equivalence_parses() {
         eq.trees,
         vec![(
             "N".into(),
-            vec![Claim {
-                name: "smt_ident".into(),
-                ty: ClaimType::Lemma,
-                dependencies: vec![]
-            }]
+            vec![
+                Claim {
+                    name: "invariant".into(),
+                    ty: ClaimType::Invariant,
+                    dependencies: vec![]
+                },
+                Claim {
+                    name: "equal-aborts".into(),
+                    ty: ClaimType::Lemma,
+                    dependencies: vec![]
+                },
+                Claim {
+                    name: "same-output".into(),
+                    ty: ClaimType::Lemma,
+                    dependencies: vec![]
+                },
+                Claim {
+                    name: "smt_ident".into(),
+                    ty: ClaimType::Lemma,
+                    dependencies: vec![]
+                },
+            ]
         )]
     );
 }

--- a/src/parser/tests/complete/mod.rs
+++ b/src/parser/tests/complete/mod.rs
@@ -158,22 +158,26 @@ fn equivalence_parses() {
                 Claim {
                     name: "invariant".into(),
                     ty: ClaimType::Invariant,
-                    dependencies: vec![]
+                    dependencies: vec![],
+                    admited: false,
                 },
                 Claim {
                     name: "equal-aborts".into(),
                     ty: ClaimType::Lemma,
-                    dependencies: vec![]
+                    dependencies: vec![],
+                    admited: false
                 },
                 Claim {
                     name: "same-output".into(),
                     ty: ClaimType::Lemma,
-                    dependencies: vec![]
+                    dependencies: vec![],
+                    admited: false
                 },
                 Claim {
                     name: "smt_ident".into(),
                     ty: ClaimType::Lemma,
-                    dependencies: vec![]
+                    dependencies: vec![],
+                    admited: false
                 },
             ]
         )]

--- a/src/parser/theorem.rs
+++ b/src/parser/theorem.rs
@@ -18,7 +18,7 @@ use crate::{
     package::{Composition, Package},
     parser::{
         error::{
-            AdmitedClaimWarning, AssumptionMappingContainsDifferentPackagesError,
+            AdmittedClaimWarning, AssumptionMappingContainsDifferentPackagesError,
             AssumptionMappingDuplicatePackageInstanceError,
             AssumptionMappingLeftGameInstanceIsNotFromAssumption, InductionStepUnprovableError,
             ReductionContainsDifferentPackagesError, UnprovenTheoremError,
@@ -884,7 +884,7 @@ pub(crate) fn verify_induction_step(
     let mut progress = true;
     let mut provable: BTreeSet<String> = step
         .iter()
-        .filter_map(|(name, _, admited)| if *admited { Some(name) } else { None })
+        .filter_map(|(name, _, admitted)| if *admitted { Some(name) } else { None })
         .cloned()
         .collect();
 
@@ -968,8 +968,8 @@ pub(crate) fn handle_hybrid<'a>(
                     oracle_name,
                     lemmas
                         .into_iter()
-                        .map(|(name, dependencies, admited)| {
-                            Claim::from_tuple((name, dependencies.into_iter().collect(), admited))
+                        .map(|(name, dependencies, admitted)| {
+                            Claim::from_tuple((name, dependencies.into_iter().collect(), admitted))
                         })
                         .collect(),
                 )
@@ -1053,8 +1053,8 @@ fn handle_equivalence<'a>(
                 oracle_name,
                 lemmas
                     .into_iter()
-                    .map(|(name, dependencies, admited)| {
-                        Claim::from_tuple((name, dependencies.into_iter().collect(), admited))
+                    .map(|(name, dependencies, admitted)| {
+                        Claim::from_tuple((name, dependencies.into_iter().collect(), admitted))
                     })
                     .collect(),
             )
@@ -1176,7 +1176,7 @@ fn handle_lemma_line(
             "admit" => {
                 eprintln!(
                     "{:?}",
-                    miette::Report::new(AdmitedClaimWarning {
+                    miette::Report::new(AdmittedClaimWarning {
                         claim: name.to_string(),
                         oracle: oracle_name.to_string(),
                         at: (span.start()..span.end()).into(),

--- a/src/parser/theorem.rs
+++ b/src/parser/theorem.rs
@@ -18,7 +18,7 @@ use crate::{
     package::{Composition, Package},
     parser::{
         error::{
-            AssumptionMappingContainsDifferentPackagesError,
+            AdmitedClaimWarning, AssumptionMappingContainsDifferentPackagesError,
             AssumptionMappingDuplicatePackageInstanceError,
             AssumptionMappingLeftGameInstanceIsNotFromAssumption, InductionStepUnprovableError,
             ReductionContainsDifferentPackagesError, UnprovenTheoremError,
@@ -1108,7 +1108,7 @@ fn handle_equivalence_oracle(
     ParseTheoremError,
 > {
     let mut ast = ast.into_inner();
-    let oracle_name = ast.next().unwrap().as_str().to_string();
+    let oracle_name = ast.next().unwrap().as_str();
     let mut invariant_paths = Vec::new();
     let mut lemmas = Vec::new();
     let mut randomness = RandomnessType::Custom;
@@ -1137,7 +1137,7 @@ fn handle_equivalence_oracle(
             }
             Rule::lemmas_spec => {
                 let span = next.as_span();
-                let new_lemmas = handle_lemmas_spec(next.into_inner());
+                let new_lemmas = handle_lemmas_spec(ctx, oracle_name, next.into_inner());
                 verify_induction_step(ctx, &new_lemmas, (span.start()..span.end()).into())?;
                 lemmas.extend(new_lemmas);
             }
@@ -1145,24 +1145,46 @@ fn handle_equivalence_oracle(
         }
     }
 
-    Ok((oracle_name, invariant_paths, lemmas, randomness))
+    Ok((oracle_name.to_string(), invariant_paths, lemmas, randomness))
 }
 
 fn handle_invariant_spec(ast: Pairs<Rule>) -> Vec<String> {
     ast.map(|ast| ast.as_str().to_string()).collect()
 }
 
-fn handle_lemmas_spec(ast: Pairs<Rule>) -> Vec<(String, BTreeSet<String>, bool)> {
-    ast.map(handle_lemma_line).collect()
+fn handle_lemmas_spec(
+    ctx: &mut ParseTheoremContext,
+    oracle_name: &str,
+    ast: Pairs<Rule>,
+) -> Vec<(String, BTreeSet<String>, bool)> {
+    ast.map(|ast| handle_lemma_line(ctx, oracle_name, ast))
+        .collect()
 }
 
-fn handle_lemma_line(ast: Pair<Rule>) -> (String, BTreeSet<String>, bool) {
+fn handle_lemma_line(
+    ctx: &mut ParseTheoremContext,
+    oracle_name: &str,
+    ast: Pair<Rule>,
+) -> (String, BTreeSet<String>, bool) {
+    let span = ast.as_span();
     let mut ast = ast.into_inner();
     let name = next_str(&mut ast).to_string();
     let admit = if matches!(ast.peek().map(|a| a.as_rule()), Some(Rule::lemma_modifier)) {
-        let modifier = ast.next().unwrap().as_str();
+        let modifier_ast = ast.next().unwrap();
+        let modifier = modifier_ast.as_str();
         match modifier {
-            "admit" => true,
+            "admit" => {
+                eprintln!(
+                    "{:?}",
+                    miette::Report::new(AdmitedClaimWarning {
+                        claim: name.to_string(),
+                        oracle: oracle_name.to_string(),
+                        at: (span.start()..span.end()).into(),
+                        source_code: ctx.named_source(),
+                    })
+                );
+                true
+            }
             _ => todo!(),
         }
     } else {

--- a/src/parser/theorem.rs
+++ b/src/parser/theorem.rs
@@ -864,25 +864,29 @@ fn handle_game_hops<'a>(
     Ok(())
 }
 
-/* Required to be proven: equal-aborts, invariant, same-output
- * Allowed to use: no-abort
- *
- * We iteratively add all claims that have all their requirements
- * met. When we can no longer add additional claims, the algorithm
- * terminates.
- *
- * As we *prove* equal-aborts but use no-abort, special care is
- * needed. We run the algorithm until equal-aborts is proven (making
- * sure it does not (even transitively) depend on no-abort. Once
- * equal-aborts is proven, we allow dependencies on no-abort.
+/** Required to be proven: equal-aborts, invariant, same-output
+ ** Allowed to use: no-abort
+ **
+ ** We iteratively add all claims that have all their requirements
+ ** met. When we can no longer add additional claims, the algorithm
+ ** terminates.
+ **
+ ** As we *prove* equal-aborts but use no-abort, special care is
+ ** needed. We run the algorithm until equal-aborts is proven (making
+ ** sure it does not (even transitively) depend on no-abort. Once
+ ** equal-aborts is proven, we allow dependencies on no-abort.
  */
 pub(crate) fn verify_induction_step(
     ctx: &mut ParseTheoremContext,
-    step: &[(String, BTreeSet<String>)],
+    step: &[(String, BTreeSet<String>, bool)],
     span: SourceSpan,
 ) -> Result<(), ParseTheoremError> {
     let mut progress = true;
-    let mut provable: BTreeSet<String> = BTreeSet::new();
+    let mut provable: BTreeSet<String> = step
+        .iter()
+        .filter_map(|(name, _, admited)| if *admited { Some(name) } else { None })
+        .cloned()
+        .collect();
 
     while progress {
         progress = false;
@@ -892,7 +896,7 @@ pub(crate) fn verify_induction_step(
 
         let mut new: BTreeSet<_> = step
             .iter()
-            .filter_map(|(name, dependencies)| {
+            .filter_map(|(name, dependencies, _)| {
                 if !provable.contains(name) && provable.is_superset(dependencies) {
                     Some(name.clone())
                 } else {
@@ -964,8 +968,8 @@ pub(crate) fn handle_hybrid<'a>(
                     oracle_name,
                     lemmas
                         .into_iter()
-                        .map(|(name, dependencies)| {
-                            Claim::from_tuple((name, dependencies.into_iter().collect()))
+                        .map(|(name, dependencies, admited)| {
+                            Claim::from_tuple((name, dependencies.into_iter().collect(), admited))
                         })
                         .collect(),
                 )
@@ -1049,8 +1053,8 @@ fn handle_equivalence<'a>(
                 oracle_name,
                 lemmas
                     .into_iter()
-                    .map(|(name, dependencies)| {
-                        Claim::from_tuple((name, dependencies.into_iter().collect()))
+                    .map(|(name, dependencies, admited)| {
+                        Claim::from_tuple((name, dependencies.into_iter().collect(), admited))
                     })
                     .collect(),
             )
@@ -1098,7 +1102,7 @@ fn handle_equivalence_oracle(
     (
         String,
         Vec<String>,
-        Vec<(String, BTreeSet<String>)>,
+        Vec<(String, BTreeSet<String>, bool)>,
         RandomnessType,
     ),
     ParseTheoremError,
@@ -1148,16 +1152,25 @@ fn handle_invariant_spec(ast: Pairs<Rule>) -> Vec<String> {
     ast.map(|ast| ast.as_str().to_string()).collect()
 }
 
-fn handle_lemmas_spec(ast: Pairs<Rule>) -> Vec<(String, BTreeSet<String>)> {
+fn handle_lemmas_spec(ast: Pairs<Rule>) -> Vec<(String, BTreeSet<String>, bool)> {
     ast.map(handle_lemma_line).collect()
 }
 
-fn handle_lemma_line(ast: Pair<Rule>) -> (String, BTreeSet<String>) {
+fn handle_lemma_line(ast: Pair<Rule>) -> (String, BTreeSet<String>, bool) {
     let mut ast = ast.into_inner();
     let name = next_str(&mut ast).to_string();
+    let admit = if matches!(ast.peek().map(|a| a.as_rule()), Some(Rule::lemma_modifier)) {
+        let modifier = ast.next().unwrap().as_str();
+        match modifier {
+            "admit" => true,
+            _ => todo!(),
+        }
+    } else {
+        false
+    };
     let deps = ast.map(|dep| dep.as_str().to_string()).collect();
 
-    (name, deps)
+    (name, deps, admit)
 }
 
 fn handle_string_triplet<'a>(

--- a/src/parser/theorem.rs
+++ b/src/parser/theorem.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use itertools::Itertools;
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 
 use crate::{
     expressions::Expression,
@@ -20,7 +20,7 @@ use crate::{
         error::{
             AssumptionMappingContainsDifferentPackagesError,
             AssumptionMappingDuplicatePackageInstanceError,
-            AssumptionMappingLeftGameInstanceIsNotFromAssumption,
+            AssumptionMappingLeftGameInstanceIsNotFromAssumption, InductionStepUnprovableError,
             ReductionContainsDifferentPackagesError, UnprovenTheoremError,
         },
         Rule,
@@ -31,7 +31,7 @@ use crate::{
     util::scope::{Declaration, Error as ScopeError, Scope},
 };
 
-use miette::{Diagnostic, NamedSource};
+use miette::{Diagnostic, NamedSource, SourceSpan};
 use pest::{
     iterators::{Pair, Pairs},
     Span,
@@ -162,6 +162,10 @@ pub enum ParseTheoremError {
     #[diagnostic(transparent)]
     #[error(transparent)]
     DuplicateGameInstanceDefinition(#[from] DuplicateGameInstanceDefinitionError),
+
+    #[diagnostic(transparent)]
+    #[error(transparent)]
+    InductionStepUnprovable(#[from] InductionStepUnprovableError),
 
     #[diagnostic(transparent)]
     #[error(transparent)]
@@ -860,6 +864,60 @@ fn handle_game_hops<'a>(
     Ok(())
 }
 
+/* Required to be proven: equal-aborts, invariant, same-output
+ * Allowed to use: no-abort
+ *
+ * We iteratively add all claims that have all their requirements
+ * met. When we can no longer add additional claims, the algorithm
+ * terminates.
+ *
+ * As we *prove* equal-aborts but use no-abort, special care is
+ * needed. We run the algorithm until equal-aborts is proven (making
+ * sure it does not (even transitively) depend on no-abort. Once
+ * equal-aborts is proven, we allow dependencies on no-abort.
+ */
+pub(crate) fn verify_induction_step(
+    ctx: &mut ParseTheoremContext,
+    step: &[(String, BTreeSet<String>)],
+    span: SourceSpan,
+) -> Result<(), ParseTheoremError> {
+    let mut progress = true;
+    let mut provable: BTreeSet<String> = BTreeSet::new();
+
+    while progress {
+        progress = false;
+        if provable.contains("equal-aborts") {
+            provable.insert("no-abort".to_string());
+        }
+
+        let mut new: BTreeSet<_> = step
+            .iter()
+            .filter_map(|(name, dependencies)| {
+                if !provable.contains(name) && provable.is_superset(dependencies) {
+                    Some(name.clone())
+                } else {
+                    None
+                }
+            })
+            .collect();
+        progress = !new.is_empty();
+        provable.append(&mut new);
+    }
+    for target_claim in ["equal-aborts", "invariant", "same-output"] {
+        if !provable.contains(target_claim) {
+            return Err(InductionStepUnprovableError {
+                source_code: ctx.named_source(),
+                at: span,
+                target: target_claim.to_string(),
+                provable: provable.into_iter().join(", "),
+            }
+            .into());
+        }
+    }
+
+    Ok(())
+}
+
 pub(crate) fn handle_hybrid<'a>(
     ctx: &mut ParseTheoremContext<'a>,
     ast: Pair<'a, Rule>,
@@ -904,7 +962,12 @@ pub(crate) fn handle_hybrid<'a>(
             .map(|(oracle_name, _, lemmas, _)| {
                 (
                     oracle_name,
-                    lemmas.into_iter().map(Claim::from_tuple).collect(),
+                    lemmas
+                        .into_iter()
+                        .map(|(name, dependencies)| {
+                            Claim::from_tuple((name, dependencies.into_iter().collect()))
+                        })
+                        .collect(),
                 )
             })
             .collect();
@@ -984,7 +1047,12 @@ fn handle_equivalence<'a>(
         .map(|(oracle_name, _, lemmas, _)| {
             (
                 oracle_name,
-                lemmas.into_iter().map(Claim::from_tuple).collect(),
+                lemmas
+                    .into_iter()
+                    .map(|(name, dependencies)| {
+                        Claim::from_tuple((name, dependencies.into_iter().collect()))
+                    })
+                    .collect(),
             )
         })
         .collect();
@@ -1030,7 +1098,7 @@ fn handle_equivalence_oracle(
     (
         String,
         Vec<String>,
-        Vec<(String, Vec<String>)>,
+        Vec<(String, BTreeSet<String>)>,
         RandomnessType,
     ),
     ParseTheoremError,
@@ -1063,7 +1131,12 @@ fn handle_equivalence_oracle(
             Rule::invariant_spec => {
                 invariant_paths.extend(handle_invariant_spec(next.into_inner()));
             }
-            Rule::lemmas_spec => lemmas.extend(handle_lemmas_spec(next.into_inner())),
+            Rule::lemmas_spec => {
+                let span = next.as_span();
+                let new_lemmas = handle_lemmas_spec(next.into_inner());
+                verify_induction_step(ctx, &new_lemmas, (span.start()..span.end()).into())?;
+                lemmas.extend(new_lemmas);
+            }
             _ => unimplemented!(),
         }
     }
@@ -1075,11 +1148,11 @@ fn handle_invariant_spec(ast: Pairs<Rule>) -> Vec<String> {
     ast.map(|ast| ast.as_str().to_string()).collect()
 }
 
-fn handle_lemmas_spec(ast: Pairs<Rule>) -> Vec<(String, Vec<String>)> {
+fn handle_lemmas_spec(ast: Pairs<Rule>) -> Vec<(String, BTreeSet<String>)> {
     ast.map(handle_lemma_line).collect()
 }
 
-fn handle_lemma_line(ast: Pair<Rule>) -> (String, Vec<String>) {
+fn handle_lemma_line(ast: Pair<Rule>) -> (String, BTreeSet<String>) {
     let mut ast = ast.into_inner();
     let name = next_str(&mut ast).to_string();
     let deps = ast.map(|dep| dep.as_str().to_string()).collect();

--- a/src/theorem.rs
+++ b/src/theorem.rs
@@ -222,19 +222,19 @@ pub struct Claim {
     pub(crate) name: String,
     pub(crate) ty: ClaimType,
     pub(crate) dependencies: Vec<String>,
-    pub(crate) admited: bool,
+    pub(crate) admitted: bool,
 }
 
 impl Claim {
     pub fn from_tuple(data: (String, Vec<String>, bool)) -> Self {
-        let (name, dependencies, admited) = data;
+        let (name, dependencies, admitted) = data;
         let ty = ClaimType::guess_from_name(&name);
 
         Self {
             name,
             ty,
             dependencies,
-            admited,
+            admitted,
         }
     }
 
@@ -250,8 +250,8 @@ impl Claim {
         &self.dependencies
     }
 
-    pub fn is_admited(&self) -> bool {
-        self.admited
+    pub fn is_admitted(&self) -> bool {
+        self.admitted
     }
 }
 

--- a/src/theorem.rs
+++ b/src/theorem.rs
@@ -222,17 +222,19 @@ pub struct Claim {
     pub(crate) name: String,
     pub(crate) ty: ClaimType,
     pub(crate) dependencies: Vec<String>,
+    pub(crate) admited: bool,
 }
 
 impl Claim {
-    pub fn from_tuple(data: (String, Vec<String>)) -> Self {
-        let (name, dependencies) = data;
+    pub fn from_tuple(data: (String, Vec<String>, bool)) -> Self {
+        let (name, dependencies, admited) = data;
         let ty = ClaimType::guess_from_name(&name);
 
         Self {
             name,
             ty,
             dependencies,
+            admited,
         }
     }
 
@@ -246,6 +248,10 @@ impl Claim {
 
     pub fn dependencies(&self) -> &[String] {
         &self.dependencies
+    }
+
+    pub fn is_admited(&self) -> bool {
+        self.admited
     }
 }
 

--- a/test-projects/test-splitinvoke/theorem/proof.ssp
+++ b/test-projects/test-splitinvoke/theorem/proof.ssp
@@ -19,6 +19,8 @@ theorem SplitInvokeProof {
                 invariant: ./theorem/invariant.smt2
                 lemmas {
                     same-output: []
+                    equal-aborts: []
+                    invariant: []
                 }
             }
         }

--- a/testdata/ssp-code/theorems/equivalence-small-small.ssp
+++ b/testdata/ssp-code/theorems/equivalence-small-small.ssp
@@ -18,6 +18,9 @@ theorem SmallIsSmall {
       N: {
         invariant: ./invariant.smt
         lemmas {
+        invariant: []
+        equal-aborts: []
+        same-output: []
         smt_ident: []
         }
       }


### PR DESCRIPTION
In this PR we make sure that all the claims used as dependencies to show that the invariant in equivalence proofs actually holds are checked. So far the user had to manually ensure that they tell Domino to check all of them.

In order to not break some of our more complex examples where we do manual checks, we introduce the `admit` keyword that tells domino to not prove this claim.

- [x] add a warning when we encounter `admit`