### PR TITLE
Remove superfluous admitted lemma for randomness for last hop in 4WHSfull.

### DIFF
--- a/example-projects/4WHS/theorem/Full4WHS.ssp
+++ b/example-projects/4WHS/theorem/Full4WHS.ssp
@@ -1489,10 +1489,9 @@ theorem Full4WHS {
                 ]
 
                 lemmas {
-                    invariant:    [no-abort, lemma-randomness]
-                    same-output:  [no-abort, lemma-randomness]
-                    equal-aborts: [lemma-randomness]
-                    lemma-randomness: admit []
+                    invariant:    [no-abort]
+                    same-output:  [no-abort]
+                    equal-aborts: []
                 }
             }
              Send3: {

--- a/example-projects/4WHS/theorem/full/randomness-H6_1-H7_0.smt2
+++ b/example-projects/4WHS/theorem/full/randomness-H6_1-H7_0.smt2
@@ -10,24 +10,6 @@
        (and (= id-0 (sample-id "PRF" "Eval" "1"))
             (= id-1 (sample-id "MAC" "Init" "1"))))))
 
-
-; rand-PRF-Eval-1
-(define-fun <relation-lemma-randomness-H6_1_1-H7_0-Send2>
-    ((H61-old <GameState_H6_<$<!n!>$>>)
-     (H70-old <GameState_H7_<$<!n!>$>>)
-     (H61-return <OracleReturn_H6_<$<!n!>$>_KX_noprfkey_<$<!n!>$>_Send2>)
-     (H70-return <OracleReturn_H7_<$<!n!>$>_KX_noprfkey_<$<!n!>$>_Send2>)
-     (ctr Int) (msg Bits_n))
-  Bool
-  (and (= (__sample-rand-H6_1_1-Bits_n (sample-id "Nonces" "Sample" "1")
-                                       (<game-H6-<$<!n!>$>-rand-Nonces-Sample-1> H61-old))
-          (__sample-rand-H7_0-Bits_n (sample-id "Nonces" "Sample" "1")
-                                       (<game-H7-<$<!n!>$>-rand-Nonces-Sample-1> H70-old)))
-       (= (__sample-rand-H6_1_1-Bits_n (sample-id "PRF" "Eval" "1")
-                                       (<game-H6-<$<!n!>$>-rand-PRF-Eval-1> H61-old))
-          (__sample-rand-H7_0-Bits_n (sample-id "MAC" "Init" "1")
-                                       (<game-H7-<$<!n!>$>-rand-MAC-Init-1> H70-old)))))
-
 (define-fun randomness-mapping-Send3
     ((id-0 SampleId) (id-1 SampleId)
      (offset-0 Int) (offset-1 Int))


### PR DESCRIPTION
I removed admitted randomness lemma from 4WHSFull, since it is not needed for cvc5. If you want to verify that it still works, this is the command:

domino prove --proof Full4WHS --proofstep 11